### PR TITLE
Remove ServiceNow integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,8 @@ See [Local vs Production Setup](docs/environments.md) for details on configuring
 3. Edit the `.env` file with your SMTP configuration and `HELPDESK_EMAIL`.
    To send tickets directly to HelpScout instead, provide
    `HELPSCOUT_API_KEY` and `HELPSCOUT_MAILBOX_ID` (optionally set
-   `HELPSCOUT_SMTP_FALLBACK=true` to also send email). Alternatively set
-   `SERVICENOW_INSTANCE`, `SERVICENOW_USER` and `SERVICENOW_PASS` to
-   create incidents in ServiceNow. You can also customize `API_PORT`,
+   `HELPSCOUT_SMTP_FALLBACK=true` to also send email).
+   ServiceNow integration has been removed. You can customize `API_PORT`,
    `LOGO_URL` and other defaults.
 4. Start the server with `node index.js` (uses `API_PORT`, default `3000`).
 
@@ -278,12 +277,9 @@ When `HELPSCOUT_API_KEY` and `HELPSCOUT_MAILBOX_ID` are defined in
 submitted to `POST /submit-ticket`. Set `HELPSCOUT_SMTP_FALLBACK=true` if you
 want the server to also send the ticket email using your SMTP configuration.
 
-## ServiceNow Integration #PENDING DEPERCATION
+## ServiceNow Integration (Deprecated)
 
-Set `SERVICENOW_INSTANCE`, `SERVICENOW_USER` and `SERVICENOW_PASS` in
-`nova-api/.env` to create incidents via ServiceNow's REST API when tickets are
-submitted. The incident ID returned by ServiceNow is stored with each log
-entry.
+ServiceNow support has been removed from the platform.
 
 ## Kiosk Activation
 
@@ -328,8 +324,6 @@ Each app relies on a few environment variables:
 - `HELPSCOUT_API_KEY`, `HELPSCOUT_MAILBOX_ID` – enable HelpScout integration
   for ticket submissions.
 - `HELPSCOUT_SMTP_FALLBACK` – set to `true` to also send email via SMTP.
-- `SERVICENOW_INSTANCE`, `SERVICENOW_USER`, `SERVICENOW_PASS` – create
-  incidents in ServiceNow instead of email.
 - `SESSION_SECRET`, `SAML_ENTRY_POINT`, `SAML_ISSUER`, `SAML_CERT`,
   `SAML_CALLBACK_URL`, `ADMIN_URL` – required for SAML login.
 - Optional: `API_PORT` (default `3000`), `LOGO_URL`, `FAVICON_URL`.

--- a/apps/api/config/environment.js
+++ b/apps/api/config/environment.js
@@ -56,7 +56,6 @@ export const validateEnvironment = () => {
     authDisabled: process.env.DISABLE_AUTH === 'true',
     hasSmtp: !!(process.env.SMTP_HOST && process.env.SMTP_USER),
     hasHelpScout: !!(process.env.HELPSCOUT_API_KEY && process.env.HELPSCOUT_MAILBOX_ID),
-    hasServiceNow: !!(process.env.SERVICENOW_INSTANCE && process.env.SERVICENOW_USER),
     hasKioskToken: !!process.env.KIOSK_TOKEN,
     hasScimToken: !!process.env.SCIM_TOKEN,
     tlsEnabled: !!(process.env.TLS_CERT_PATH && process.env.TLS_KEY_PATH)
@@ -92,9 +91,6 @@ export const getConfig = () => {
     SMTP_SECURE: process.env.SMTP_SECURE === 'true',
     HELPDESK_EMAIL: process.env.HELPDESK_EMAIL,
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL,
-    SERVICENOW_INSTANCE: process.env.SERVICENOW_INSTANCE,
-    SERVICENOW_USER: process.env.SERVICENOW_USER,
-    SERVICENOW_PASS: process.env.SERVICENOW_PASS,
     HELPSCOUT_API_KEY: process.env.HELPSCOUT_API_KEY,
     HELPSCOUT_MAILBOX_ID: process.env.HELPSCOUT_MAILBOX_ID,
     HELPSCOUT_SMTP_FALLBACK: process.env.HELPSCOUT_SMTP_FALLBACK === 'true'
@@ -109,7 +105,6 @@ export const logEnvironmentStatus = () => {
   console.log(`🔐 Authentication: ${config.authDisabled ? 'DISABLED' : 'ENABLED'}`);
   console.log(`📧 Email: ${config.hasSmtp ? 'CONFIGURED' : 'NOT CONFIGURED'}`);
   console.log(`🎫 HelpScout: ${config.hasHelpScout ? 'CONFIGURED' : 'NOT CONFIGURED'}`);
-  console.log(`🏢 ServiceNow: ${config.hasServiceNow ? 'CONFIGURED' : 'NOT CONFIGURED'}`);
   console.log(`📱 Kiosk Token: ${config.hasKioskToken ? 'CONFIGURED' : 'NOT CONFIGURED'}`);
   console.log(`🔐 SCIM Token: ${config.hasScimToken ? 'CONFIGURED' : 'NOT CONFIGURED'}`);
   console.log(`🔒 TLS: ${config.tlsEnabled ? 'ENABLED' : 'DISABLED'}`);

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -49,7 +49,7 @@ import orbitRouter from './routes/orbit.js';
 import pulseRouter from './routes/pulse.js';
 import scimRouter from './routes/scim.js';
 import synthRouter from './routes/synth.js';
-import { getEmailStrategy, getServiceNowConfig } from './utils/serviceHelpers.js';
+import { getEmailStrategy } from './utils/serviceHelpers.js';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);

--- a/apps/api/migrations/postgresql/20250124000001_initial_schema.sql
+++ b/apps/api/migrations/postgresql/20250124000001_initial_schema.sql
@@ -163,7 +163,6 @@ CREATE TABLE IF NOT EXISTS logs (
     email_sent_at TIMESTAMP,
     
     -- External integrations
-    servicenow_id VARCHAR(100),
     external_refs JSONB DEFAULT '{}',
     
     -- Metadata

--- a/apps/api/test/serviceHelpers.test.js
+++ b/apps/api/test/serviceHelpers.test.js
@@ -1,62 +1,15 @@
 import 'dotenv/config';
 import assert from 'assert';
-import { isServiceNowConfigured, getServiceNowConfig, isHelpScoutConfigured, getHelpScoutConfig, getEmailStrategy } from '../utils/serviceHelpers.js';
+import { isHelpScoutConfigured, getHelpScoutConfig, getEmailStrategy } from '../utils/serviceHelpers.js';
 
 describe('Service Helpers', function () {
   beforeEach(() => {
     // Clear relevant environment variables before each test
-    delete process.env.SERVICENOW_INSTANCE;
-    delete process.env.SERVICENOW_USER;
-    delete process.env.SERVICENOW_PASS;
     delete process.env.HELPSCOUT_API_KEY;
     delete process.env.HELPSCOUT_MAILBOX_ID;
     delete process.env.HELPSCOUT_SMTP_FALLBACK;
   });
 
-  describe('ServiceNow Configuration', function () {
-    it('should return false when ServiceNow is not configured', function () {
-      assert.strictEqual(isServiceNowConfigured(), false);
-    });
-
-    it('should return false when only instance is configured', function () {
-      process.env.SERVICENOW_INSTANCE = 'https://test.service-now.com';
-      assert.strictEqual(isServiceNowConfigured(), false);
-    });
-
-    it('should return false when only user is configured', function () {
-      process.env.SERVICENOW_USER = 'testuser';
-      assert.strictEqual(isServiceNowConfigured(), false);
-    });
-
-    it('should return false when only password is configured', function () {
-      process.env.SERVICENOW_PASS = 'testpass';
-      assert.strictEqual(isServiceNowConfigured(), false);
-    });
-
-    it('should return true when all ServiceNow credentials are configured', function () {
-      process.env.SERVICENOW_INSTANCE = 'https://test.service-now.com';
-      process.env.SERVICENOW_USER = 'testuser';
-      process.env.SERVICENOW_PASS = 'testpass';
-      assert.strictEqual(isServiceNowConfigured(), true);
-    });
-
-    it('should return null config when ServiceNow is not configured', function () {
-      assert.strictEqual(getServiceNowConfig(), null);
-    });
-
-    it('should return valid config when ServiceNow is configured', function () {
-      process.env.SERVICENOW_INSTANCE = 'https://test.service-now.com';
-      process.env.SERVICENOW_USER = 'testuser';
-      process.env.SERVICENOW_PASS = 'testpass';
-      
-      const config = getServiceNowConfig();
-      assert.deepStrictEqual(config, {
-        instance: 'https://test.service-now.com',
-        user: 'testuser',
-        pass: 'testpass'
-      });
-    });
-  });
 
   describe('HelpScout Configuration', function () {
     it('should return false when HelpScout is not configured', function () {

--- a/apps/api/utils/serviceHelpers.js
+++ b/apps/api/utils/serviceHelpers.js
@@ -4,34 +4,6 @@
  */
 
 /**
- * Checks if ServiceNow integration is properly configured
- * @returns {boolean} True if ServiceNow can be used, false otherwise
- */
-export function isServiceNowConfigured() {
-  const SN_INSTANCE = process.env.SERVICENOW_INSTANCE;
-  const SN_USER = process.env.SERVICENOW_USER;
-  const SN_PASS = process.env.SERVICENOW_PASS;
-  
-  return !!(SN_INSTANCE && SN_USER && SN_PASS);
-}
-
-/**
- * Gets ServiceNow configuration if available
- * @returns {Object|null} ServiceNow config object or null if not configured
- */
-export function getServiceNowConfig() {
-  if (!isServiceNowConfigured()) {
-    return null;
-  }
-  
-  return {
-    instance: process.env.SERVICENOW_INSTANCE,
-    user: process.env.SERVICENOW_USER,
-    pass: process.env.SERVICENOW_PASS
-  };
-}
-
-/**
  * Checks if HelpScout integration is properly configured
  * @returns {boolean} True if HelpScout can be used, false otherwise
  */

--- a/apps/core/nova-core/src/lib/mockData.ts
+++ b/apps/core/nova-core/src/lib/mockData.ts
@@ -179,19 +179,6 @@ export const mockIntegrations: Integration[] = [
       mailboxId: '123456'
     },
     working: true
-  },
-  {
-    id: 3,
-    name: 'ServiceNow Dev',
-    type: 'servicenow',
-    enabled: false,
-    settings: {},
-    config: {
-      instanceUrl: 'https://company-dev.service-now.com',
-      username: 'api_user'
-    },
-    working: false,
-    lastError: 'Authentication failed'
   }
 ];
 

--- a/apps/core/nova-core/src/pages/IntegrationsPage.tsx
+++ b/apps/core/nova-core/src/pages/IntegrationsPage.tsx
@@ -15,7 +15,6 @@ import type { Integration } from '@/types';
 const integrationTypes = [
   { value: 'smtp', label: 'SMTP Email' },
   { value: 'helpscout', label: 'Help Scout' },
-  { value: 'servicenow', label: 'ServiceNow' },
   { value: 'slack', label: 'Slack' },
   { value: 'teams', label: 'Microsoft Teams' },
   { value: 'webhook', label: 'Generic Webhook' },
@@ -346,40 +345,6 @@ export const IntegrationsPage: React.FC = () => {
                 config: { ...formData.config, webhookUrl: e.target.value }
               })}
               placeholder="https://your-tenant.webhook.office.com/..."
-              required
-            />
-          </div>
-        );
-      case 'servicenow':
-        return (
-          <div className="space-y-4">
-            <Input
-              label="Instance URL"
-              value={formData.config.instanceUrl || ''}
-              onChange={(e) => setFormData({
-                ...formData,
-                config: { ...formData.config, instanceUrl: e.target.value }
-              })}
-              placeholder="https://your-instance.service-now.com"
-              required
-            />
-            <Input
-              label="Username"
-              value={formData.config.username || ''}
-              onChange={(e) => setFormData({
-                ...formData,
-                config: { ...formData.config, username: e.target.value }
-              })}
-              required
-            />
-            <Input
-              label="Password"
-              type="password"
-              value={formData.config.password || ''}
-              onChange={(e) => setFormData({
-                ...formData,
-                config: { ...formData.config, password: e.target.value }
-              })}
               required
             />
           </div>

--- a/apps/core/nova-core/src/types/index.d.ts
+++ b/apps/core/nova-core/src/types/index.d.ts
@@ -115,7 +115,7 @@ export interface DirectoryUser {
 export interface Integration {
     id: number;
     name: string;
-    type: 'smtp' | 'helpscout' | 'servicenow' | 'slack' | 'teams' | 'webhook';
+    type: 'smtp' | 'helpscout' | 'slack' | 'teams' | 'webhook';
     enabled: boolean;
     settings: Record<string, unknown>;
     config?: Record<string, unknown>;

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -135,7 +135,7 @@ export interface DirectoryUser {
 export interface Integration {
   id: number;
   name: string;
-  type: 'smtp' | 'helpscout' | 'servicenow' | 'slack' | 'teams' | 'webhook';
+  type: 'smtp' | 'helpscout' | 'slack' | 'teams' | 'webhook';
   enabled: boolean;
   settings: Record<string, unknown>;
   config?: Record<string, unknown>;

--- a/docs/Feature_Inventory.md
+++ b/docs/Feature_Inventory.md
@@ -63,7 +63,7 @@ This document provides a comprehensive inventory of features, modules, and submo
 
 ### Integrations
 - **Slack**: Slash commands and notifications.
-- **ServiceNow**: Incident creation.
+- **ServiceNow**: ~~Incident creation (deprecated)~~
 - **HelpScout**: Ticket synchronization.
 
 ### Knowledge Base
@@ -82,7 +82,7 @@ This document provides a comprehensive inventory of features, modules, and submo
 
 ### Third-Party Integrations
 - **Slack and Teams**: Enhanced collaboration.
-- **ServiceNow and HelpScout**: Remove ServiceNow integration and create and Import Only HelpScout intergration.
+ - **ServiceNow**: Integration removed. HelpScout supports import-only mode.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Express.js backend with PostgreSQL database. Handles ticket submission, user man
 - PostgreSQL database with automatic migrations
 - Comprehensive security middleware
 - Rate limiting and input validation
-- Integration with HelpScout, ServiceNow, and Slack
+- Integration with HelpScout and Slack (ServiceNow integration deprecated)
 
 ### cueit-admin
 React admin interface for managing the help desk system.

--- a/docs/admin-ui-configuration.md
+++ b/docs/admin-ui-configuration.md
@@ -88,7 +88,7 @@ All components support dark mode with proper contrast:
 - **Slack:** Tests webhook connectivity and channel access
 - **Teams:** Tests webhook URL and Microsoft Teams integration
 - **Help Scout:** Tests API key validity and mailbox access
-- **ServiceNow:** Tests instance connection and authentication
+- **ServiceNow:** Integration removed
 - **Generic Webhook:** Tests URL response and payload delivery
 
 ## Kiosk Activation Codes

--- a/docs/reports/PRE_PRODUCTION_FIXES_COMPLETE.md
+++ b/docs/reports/PRE_PRODUCTION_FIXES_COMPLETE.md
@@ -83,7 +83,7 @@
 - ✅ Server starts successfully on http://localhost:3000
 - ✅ Integrations endpoint returns proper JSON structure
 - ✅ SMTP integration enabled by default
-- ✅ All 6 integration types available (SMTP, Help Scout, ServiceNow, Slack, Teams, Webhook)
+- ✅ Integrations available: SMTP, Help Scout, Slack, Teams, Webhook (ServiceNow removed)
 
 ### Admin Interface Testing  
 - ✅ Admin interface starts on http://localhost:5175

--- a/packages/database/database/migrations.js
+++ b/packages/database/database/migrations.js
@@ -272,7 +272,6 @@ CREATE TABLE IF NOT EXISTS logs (
   urgency VARCHAR(50),
   timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   email_status VARCHAR(50),
-  servicenow_id VARCHAR(100)
 );
 
 -- Configuration table

--- a/prisma/migrations/20250727185931_init/migration.sql
+++ b/prisma/migrations/20250727185931_init/migration.sql
@@ -86,7 +86,6 @@ CREATE TABLE "logs" (
     "urgency" TEXT,
     "timestamp" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "emailStatus" TEXT,
-    "servicenowId" TEXT,
     "userId" TEXT,
 
     CONSTRAINT "logs_pkey" PRIMARY KEY ("id")

--- a/prisma/migrations/20250728022400_fix_role_permissions_snake_case/migration.sql
+++ b/prisma/migrations/20250728022400_fix_role_permissions_snake_case/migration.sql
@@ -31,7 +31,6 @@
   - You are about to drop the column `createdAt` on the `knowledge_base_articles` table. All the data in the column will be lost.
   - You are about to drop the column `updatedAt` on the `knowledge_base_articles` table. All the data in the column will be lost.
   - You are about to drop the column `emailStatus` on the `logs` table. All the data in the column will be lost.
-  - You are about to drop the column `servicenowId` on the `logs` table. All the data in the column will be lost.
   - You are about to drop the column `ticketId` on the `logs` table. All the data in the column will be lost.
   - You are about to drop the column `userId` on the `logs` table. All the data in the column will be lost.
   - You are about to drop the column `createdAt` on the `notifications` table. All the data in the column will be lost.
@@ -181,11 +180,9 @@ ADD COLUMN     "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
 -- AlterTable
 ALTER TABLE "logs" DROP COLUMN "emailStatus",
-DROP COLUMN "servicenowId",
 DROP COLUMN "ticketId",
 DROP COLUMN "userId",
 ADD COLUMN     "email_status" TEXT,
-ADD COLUMN     "servicenow_id" TEXT,
 ADD COLUMN     "ticket_id" TEXT,
 ADD COLUMN     "user_id" TEXT;
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,7 +107,6 @@ model Log {
   urgency      String?
   timestamp    DateTime @default(now())
   emailStatus  String?  @map("email_status")
-  servicenowId String?  @map("servicenow_id")
   userId       String?  @map("user_id")
   user         User?    @relation(fields: [userId], references: [id])
 


### PR DESCRIPTION
## Summary
- remove `servicenow_id` from Prisma schema and migrations
- drop ServiceNow checks in helper utils
- delete ServiceNow tests
- remove ServiceNow UI references and types
- update docs to note ServiceNow integration is deprecated

## Testing
- `npm test` *(fails: Can't find a root directory while resolving a config file path)*

------
https://chatgpt.com/codex/tasks/task_e_6887907872d883339631eafcdbb9c1c5