### PR TITLE
Use POSTGRES_PASSWORD env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=nova_universe
 POSTGRES_USER=nova_user
+# PostgreSQL password (required)
 POSTGRES_PASSWORD=secure_password_here
 
 # PostgreSQL Connection Pool
@@ -202,7 +203,8 @@ POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 POSTGRES_DB=nova_universe
 POSTGRES_USER=nova_admin
-POSTGRES_PASSWORD=nova_secure_pass_2024
+# PostgreSQL password (required)
+POSTGRES_PASSWORD=secure_password_here
 
 # SSL/TLS settings (enable for production)
 POSTGRES_SSL_REJECT_UNAUTHORIZED=false

--- a/apps/api/config/database.js
+++ b/apps/api/config/database.js
@@ -16,7 +16,7 @@ export const databaseConfig = {
     port: parseInt(process.env.POSTGRES_PORT || '5432'),
     database: process.env.POSTGRES_DB || 'nova_universe',
     user: process.env.POSTGRES_USER || 'nova_admin',
-    password: 'nova_secure_pass_2024', // HARDCODED for debug
+    password: process.env.POSTGRES_PASSWORD,
     
     // SSL/TLS configuration
     ssl: process.env.NODE_ENV === 'production' ? {

--- a/apps/api/test/00_setup.js
+++ b/apps/api/test/00_setup.js
@@ -1,7 +1,7 @@
 import 'dotenv/config';
 process.env.POSTGRES_HOST = 'localhost';
 process.env.POSTGRES_USER = 'nova_admin';
-process.env.POSTGRES_PASSWORD = 'nova_secure_pass_2024';
+process.env.POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD || 'postgres';
 
 import nodemailer from 'nodemailer';
 import axios from 'axios';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-nova_universe}
       POSTGRES_USER: ${POSTGRES_USER:-nova_admin}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-nova_secure_pass_2024}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_INITDB_ARGS: "--encoding=UTF8 --locale=en_US.UTF-8"
     ports:
       - "${POSTGRES_PORT:-5432}:5432"
@@ -211,7 +211,7 @@ services:
   #   restart: unless-stopped
   #   environment:
   #     NODE_ENV: development
-  #     DATABASE_URL: postgres://nova_admin:nova_secure_pass_2024@postgres:5432/nova_universe
+  #     DATABASE_URL: postgres://nova_admin:${POSTGRES_PASSWORD}@postgres:5432/nova_universe
   #     MONGO_URL: mongodb://admin:mongo_secure_pass_2024@mongodb:27017/nova_logs
   #     # Add any other required environment variables here
   #   ports:


### PR DESCRIPTION
## Summary
- pull password from POSTGRES_PASSWORD in API config
- add POSTGRES_PASSWORD docs to `.env.example`
- reference env var in docker compose
- update tests to use env var default

## Testing
- `npm test` *(fails: Can't find a root directory while resolving a config file path)*

------
https://chatgpt.com/codex/tasks/task_e_688794a68b90833394190be8c7ad29a4