### PR TITLE
Add nova-pulse frontend

### DIFF
--- a/apps/pulse/nova-pulse/index.html
+++ b/apps/pulse/nova-pulse/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nova Pulse</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/pulse/nova-pulse/package.json
+++ b/apps/pulse/nova-pulse/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "nova-pulse",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@nova-universe/theme": "file:../../packages/theme",
+    "@nova-universe/ui": "file:../../packages/ui",
+    "@tanstack/react-query": "^5.83.0",
+    "axios": "^1.11.0",
+    "clsx": "^2.1.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^7.7.0",
+    "zustand": "^4.5.5"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@typescript-eslint/eslint-plugin": "^8.38.0",
+    "@typescript-eslint/parser": "^8.38.0",
+    "@vitejs/plugin-react": "^4.7.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-refresh": "^0.4.9",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "typescript": "^5.5.4",
+    "vite": "^7.0.6"
+  }
+}

--- a/apps/pulse/nova-pulse/postcss.config.js
+++ b/apps/pulse/nova-pulse/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/apps/pulse/nova-pulse/src/App.tsx
+++ b/apps/pulse/nova-pulse/src/App.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { DashboardPage } from './pages/DashboardPage'
+import { TicketsPage } from './pages/TicketsPage'
+import { DeepWorkPage } from './pages/DeepWorkPage'
+import { GamificationPage } from './pages/GamificationPage'
+import { AlertsPage } from './pages/AlertsPage'
+
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { refetchOnWindowFocus: false } }
+})
+
+const App: React.FC = () => (
+  <QueryClientProvider client={queryClient}>
+    <Router>
+      <Routes>
+        <Route path="/" element={<DashboardPage />} />
+        <Route path="/tickets" element={<TicketsPage />} />
+        <Route path="/tickets/:ticketId" element={<DeepWorkPage />} />
+        <Route path="/alerts" element={<AlertsPage />} />
+        <Route path="/gamification" element={<GamificationPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Router>
+  </QueryClientProvider>
+)
+
+export default App

--- a/apps/pulse/nova-pulse/src/components/AlertsFeed.tsx
+++ b/apps/pulse/nova-pulse/src/components/AlertsFeed.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { List, ListItem, ListItemText } from '@nova-universe/ui'
+
+interface Alert {
+  id: string
+  message: string
+  createdAt: string
+}
+
+interface Props {
+  alerts: Alert[]
+}
+
+export const AlertsFeed: React.FC<Props> = ({ alerts }) => (
+  <List className="space-y-2">
+    {alerts.map(a => (
+      <ListItem key={a.id} divider>
+        <ListItemText primary={a.message} secondary={new Date(a.createdAt).toLocaleString()} />
+      </ListItem>
+    ))}
+  </List>
+)

--- a/apps/pulse/nova-pulse/src/components/QueueSwitcher.tsx
+++ b/apps/pulse/nova-pulse/src/components/QueueSwitcher.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Select, MenuItem } from '@nova-universe/ui'
+
+interface Props {
+  queues: string[]
+  value: string
+  onChange: (val: string) => void
+}
+
+export const QueueSwitcher: React.FC<Props> = ({ queues, value, onChange }) => (
+  <Select value={value} onChange={e => onChange((e.target as HTMLSelectElement).value)} className="mb-4">
+    {queues.map(q => (
+      <MenuItem key={q} value={q}>
+        {q}
+      </MenuItem>
+    ))}
+  </Select>
+)

--- a/apps/pulse/nova-pulse/src/components/TicketGrid.tsx
+++ b/apps/pulse/nova-pulse/src/components/TicketGrid.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Table, TableHead, TableBody, TableRow, TableCell, TableContainer } from '@nova-universe/ui'
+import type { Ticket } from '../types'
+
+interface Props {
+  tickets: Ticket[]
+  onSelect?: (ticket: Ticket) => void
+}
+
+export const TicketGrid: React.FC<Props> = ({ tickets, onSelect }) => (
+  <TableContainer className="overflow-x-auto">
+    <Table className="min-w-full text-sm">
+      <TableHead>
+        <TableRow>
+          <TableCell>ID</TableCell>
+          <TableCell>Title</TableCell>
+          <TableCell>Priority</TableCell>
+          <TableCell>Status</TableCell>
+        </TableRow>
+      </TableHead>
+      <TableBody>
+        {tickets.map(t => (
+          <TableRow
+            key={t.ticketId}
+            onClick={() => onSelect?.(t)}
+            className="hover:bg-gray-100 cursor-pointer"
+          >
+            <TableCell>{t.ticketId}</TableCell>
+            <TableCell>{t.title}</TableCell>
+            <TableCell>{t.priority}</TableCell>
+            <TableCell>{t.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  </TableContainer>
+)

--- a/apps/pulse/nova-pulse/src/index.css
+++ b/apps/pulse/nova-pulse/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  * {
+    @apply border-gray-200 dark:border-gray-700;
+  }
+
+  body {
+    @apply bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+  }
+
+  .dark {
+    color-scheme: dark;
+  }
+}

--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -1,0 +1,24 @@
+import axios from 'axios'
+import type { Ticket, DashboardData, TimesheetEntry } from '../types'
+
+const client = axios.create({ baseURL: '/api/v1/pulse' })
+
+export const getDashboard = async () => {
+  const { data } = await client.get<{ success: boolean; dashboard: DashboardData }>('/dashboard')
+  return data.dashboard
+}
+
+export const getTickets = async (params?: Record<string, string | number>) => {
+  const { data } = await client.get<{ success: boolean; tickets: Ticket[] }>('/tickets', { params })
+  return data.tickets
+}
+
+export const updateTicket = async (ticketId: string, updates: Partial<Ticket> & { status?: string; workNote?: string; timeSpent?: number; resolution?: string }) => {
+  const { data } = await client.put(`/tickets/${ticketId}/update`, updates)
+  return data
+}
+
+export const getTimesheet = async (params?: Record<string, string>) => {
+  const { data } = await client.get<{ success: boolean; timesheet: TimesheetEntry[] }>('/timesheet', { params })
+  return data.timesheet
+}

--- a/apps/pulse/nova-pulse/src/main.tsx
+++ b/apps/pulse/nova-pulse/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/apps/pulse/nova-pulse/src/pages/AlertsPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/AlertsPage.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { AlertsFeed } from '../components/AlertsFeed'
+
+// Placeholder alerts until API route exists
+const sampleAlerts = [
+  { id: '1', message: 'Server CPU high', createdAt: new Date().toISOString() },
+  { id: '2', message: 'New security incident', createdAt: new Date().toISOString() }
+]
+
+export const AlertsPage: React.FC = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-4">Alerts</h2>
+    <AlertsFeed alerts={sampleAlerts} />
+  </div>
+)

--- a/apps/pulse/nova-pulse/src/pages/DashboardPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DashboardPage.tsx
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query'
 import { getDashboard, getTimesheet } from '../lib/api'
 
 export const DashboardPage: React.FC = () => {
-  const { data: dashboard } = useQuery(['dashboard'], getDashboard)
-  const { data: timesheet } = useQuery(['timesheet'], () => getTimesheet())
+  const { data: dashboard } = useQuery({ queryKey: ['dashboard'], queryFn: getDashboard })
+  const { data: timesheet } = useQuery({ queryKey: ['timesheet'], queryFn: () => getTimesheet() })
 
   if (!dashboard || !timesheet) return <div>Loading...</div>
 

--- a/apps/pulse/nova-pulse/src/pages/DashboardPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DashboardPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getDashboard, getTimesheet } from '../lib/api'
+
+export const DashboardPage: React.FC = () => {
+  const { data: dashboard } = useQuery(['dashboard'], getDashboard)
+  const { data: timesheet } = useQuery(['timesheet'], () => getTimesheet())
+
+  if (!dashboard || !timesheet) return <div>Loading...</div>
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold mb-2">My Tickets</h2>
+        <p>Total: {dashboard.myTickets.total}</p>
+        <p>Open: {dashboard.myTickets.open}</p>
+      </div>
+      <div>
+        <h3 className="text-lg font-semibold mb-2">Timesheet (last entries)</h3>
+        <ul className="list-disc pl-5">
+          {timesheet.slice(0, 5).map(t => (
+            <li key={t.ticketId}>{t.title} - {t.timeSpent}m</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { useQuery } from '@tanstack/react-query'
+import { getTickets, updateTicket } from '../lib/api'
+
+export const DeepWorkPage: React.FC = () => {
+  const { ticketId } = useParams<{ ticketId: string }>()
+  const { data } = useQuery(['ticket', ticketId], () => getTickets({ ticketId }).then(t => t[0]), { enabled: !!ticketId })
+  const [note, setNote] = React.useState('')
+
+  if (!data) return <div>Loading...</div>
+
+  const handleUpdate = async () => {
+    await updateTicket(ticketId!, { workNote: note })
+    setNote('')
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-semibold">{data.title}</h2>
+      <p>Status: {data.status}</p>
+      <textarea value={note} onChange={e => setNote(e.target.value)} className="w-full border" />
+      <button className="btn-primary" onClick={handleUpdate}>Add Note</button>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
@@ -5,7 +5,7 @@ import { getTickets, updateTicket } from '../lib/api'
 
 export const DeepWorkPage: React.FC = () => {
   const { ticketId } = useParams<{ ticketId: string }>()
-  const { data } = useQuery(['ticket', ticketId], () => getTickets({ ticketId }).then(t => t[0]), { enabled: !!ticketId })
+  const { data } = useQuery({ queryKey: { key: 'ticket', ticketId }, queryFn: () => getTickets({ ticketId }).then(t => t[0]), enabled: !!ticketId })
   const [note, setNote] = React.useState('')
 
   if (!data) return <div>Loading...</div>

--- a/apps/pulse/nova-pulse/src/pages/GamificationPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/GamificationPage.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+export const GamificationPage: React.FC = () => (
+  <div>
+    <h2 className="text-xl font-semibold mb-4">Gamification</h2>
+    <p>Track your Stardust XP and achievements here.</p>
+  </div>
+)

--- a/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
@@ -8,7 +8,7 @@ const QUEUES = ['HR', 'IT', 'Operations', 'Cyber']
 
 export const TicketsPage: React.FC = () => {
   const [queue, setQueue] = React.useState(QUEUES[0])
-  const { data: tickets = [], refetch } = useQuery(['tickets', queue], () => getTickets({ queue }))
+  const { data: tickets = [], refetch } = useQuery({ queryKey: { key: 'tickets', queue }, queryFn: () => getTickets({ queue }) })
 
   return (
     <div>

--- a/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getTickets } from '../lib/api'
+import { TicketGrid } from '../components/TicketGrid'
+import { QueueSwitcher } from '../components/QueueSwitcher'
+
+const QUEUES = ['HR', 'IT', 'Operations', 'Cyber']
+
+export const TicketsPage: React.FC = () => {
+  const [queue, setQueue] = React.useState(QUEUES[0])
+  const { data: tickets = [], refetch } = useQuery(['tickets', queue], () => getTickets({ queue }))
+
+  return (
+    <div>
+      <QueueSwitcher queues={QUEUES} value={queue} onChange={q => { setQueue(q); refetch() }} />
+      <TicketGrid tickets={tickets} onSelect={t => window.location.assign(`/tickets/${t.ticketId}`)} />
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -1,0 +1,36 @@
+export interface Ticket {
+  id: number
+  ticketId: string
+  title: string
+  priority: string
+  status: string
+  category?: string
+  subcategory?: string
+  requestedBy: { id: number; name: string }
+  assignedTo?: { id: number; name: string }
+  createdAt: string
+  updatedAt: string
+}
+
+export interface DashboardData {
+  myTickets: {
+    total: number
+    open: number
+    inProgress: number
+    resolved: number
+  }
+  todayStats: {
+    ticketsResolved: number
+    avgResolutionTime: number
+    totalTimeLogged: number
+  }
+  upcomingTasks: Ticket[]
+  recentActivity: { ticketId: string; action: string; timestamp: string }[]
+}
+
+export interface TimesheetEntry {
+  ticketId: string
+  title: string
+  timeSpent: number
+  date: string
+}

--- a/apps/pulse/nova-pulse/tailwind.config.js
+++ b/apps/pulse/nova-pulse/tailwind.config.js
@@ -1,0 +1,22 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#eff6ff',
+          500: '#3b82f6',
+          600: '#2563eb',
+          700: '#1d4ed8',
+          900: '#1e3a8a',
+        },
+      },
+    },
+  },
+  plugins: [],
+}

--- a/apps/pulse/nova-pulse/tsconfig.json
+++ b/apps/pulse/nova-pulse/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tools/config/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@nova-universe/ui": ["../../packages/ui/dist/index.js"],
+      "@nova-universe/theme": ["../../packages/theme/dist/theme.js"]
+    },
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/apps/pulse/nova-pulse/tsconfig.node.json
+++ b/apps/pulse/nova-pulse/tsconfig.node.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/pulse/nova-pulse/vite.config.ts
+++ b/apps/pulse/nova-pulse/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      '@nova-universe/ui': path.resolve(__dirname, '../../packages/ui/dist/index.js'),
+      '@nova-universe/theme': path.resolve(__dirname, '../../packages/theme/dist/theme.js'),
+    },
+  },
+  server: {
+    port: 5180,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true,
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - 'apps/*'
+  - 'apps/*/*'
   - 'packages/*'
   - 'tools/*'

--- a/tools/scripts/scripts/start-all.ps1
+++ b/tools/scripts/scripts/start-all.ps1
@@ -3,9 +3,10 @@ $apps = @{
   api      = @{ dir = 'nova-api';      cmd = 'npm --prefix nova-api start' }
   core     = @{ dir = 'nova-core';     cmd = 'npm --prefix nova-core run dev' }
   comms    = @{ dir = 'nova-comms';    cmd = 'npm --prefix nova-comms start' }
+  pulse    = @{ dir = 'nova-pulse';    cmd = 'npm --prefix nova-pulse run dev' }
 }
 
-$input = Read-Host "Apps to start (api,core,comms or all) [all]"
+$input = Read-Host "Apps to start (api,core,comms,pulse or all) [all]"
 if ([string]::IsNullOrWhiteSpace($input) -or $input -eq 'all') {
   $selected = $apps.Keys
 } else {

--- a/tools/scripts/scripts/start-all.sh
+++ b/tools/scripts/scripts/start-all.sh
@@ -8,6 +8,7 @@ get_dir() {
     api) echo "nova-api" ;;
     core) echo "nova-core" ;;
     comms) echo "nova-comms" ;;
+    pulse) echo "nova-pulse" ;;
     *) return 1 ;;
   esac
 }
@@ -17,13 +18,14 @@ get_cmd() {
     api) echo "npm --prefix nova-api start" ;;
     core) echo "npm --prefix nova-core run dev" ;;
     comms) echo "npm --prefix nova-comms start" ;;
+    pulse) echo "npm --prefix nova-pulse run dev" ;;
     *) return 1 ;;
   esac
 }
 
-read -rp "Apps to start (api,core,comms or all) [all]: " INPUT
+read -rp "Apps to start (api,core,comms,pulse or all) [all]: " INPUT
 if [[ -z "$INPUT" || "$INPUT" == "all" ]]; then
-  SELECTED=(api core comms)
+  SELECTED=(api core comms pulse)
 else
   IFS=',' read -ra SELECTED <<< "$INPUT"
 fi


### PR DESCRIPTION
## Summary
- add new React+TS project `apps/pulse/nova-pulse`
- implement ticket grid, deep work view, queue switcher, alerts feed and gamification pages
- add API client for Pulse routes
- include nova-pulse in workspace and start scripts

## Testing
- `npm test` *(fails: Cannot find module '/workspace/nova-universe/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_6887abfea4388333b1ed541708525a6a