### PR TITLE
Fix navigation and clarify ticket update type

### DIFF
--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Ticket, DashboardData, TimesheetEntry } from '../types'
+import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate } from '../types'
 
 const client = axios.create({ baseURL: '/api/v1/pulse' })
 
@@ -13,7 +13,7 @@ export const getTickets = async (params?: Record<string, string | number>) => {
   return data.tickets
 }
 
-export const updateTicket = async (ticketId: string, updates: Partial<Ticket> & { status?: string; workNote?: string; timeSpent?: number; resolution?: string }) => {
+export const updateTicket = async (ticketId: string, updates: TicketUpdate) => {
   const { data } = await client.put(`/tickets/${ticketId}/update`, updates)
   return data
 }

--- a/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/TicketsPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { useQuery } from '@tanstack/react-query'
+import { useNavigate } from 'react-router-dom'
 import { getTickets } from '../lib/api'
 import { TicketGrid } from '../components/TicketGrid'
 import { QueueSwitcher } from '../components/QueueSwitcher'
@@ -9,11 +10,12 @@ const QUEUES = ['HR', 'IT', 'Operations', 'Cyber']
 export const TicketsPage: React.FC = () => {
   const [queue, setQueue] = React.useState(QUEUES[0])
   const { data: tickets = [], refetch } = useQuery({ queryKey: { key: 'tickets', queue }, queryFn: () => getTickets({ queue }) })
+  const navigate = useNavigate()
 
   return (
     <div>
       <QueueSwitcher queues={QUEUES} value={queue} onChange={q => { setQueue(q); refetch() }} />
-      <TicketGrid tickets={tickets} onSelect={t => window.location.assign(`/tickets/${t.ticketId}`)} />
+      <TicketGrid tickets={tickets} onSelect={t => navigate(`/tickets/${t.ticketId}`)} />
     </div>
   )
 }

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -12,6 +12,13 @@ export interface Ticket {
   updatedAt: string
 }
 
+export interface TicketUpdate extends Partial<Ticket> {
+  status?: string
+  workNote?: string
+  timeSpent?: number
+  resolution?: string
+}
+
 export interface DashboardData {
   myTickets: {
     total: number

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -13,10 +13,8 @@ export interface Ticket {
 }
 
 export interface TicketUpdate extends Partial<Ticket> {
-  status?: string
   workNote?: string
   timeSpent?: number
-  resolution?: string
 }
 
 export interface DashboardData {


### PR DESCRIPTION
## Summary
- use `useNavigate` for ticket selection links
- define `TicketUpdate` type for clarity
- update API call to use the new type

## Testing
- `npm test` *(fails: Can't find a root directory while resolving a config file path)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1a648888333b80dfcee4715309a