### PR TITLE
Remove ServiceNow references

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ See [Local vs Production Setup](docs/environments.md) for details on configuring
    To send tickets directly to HelpScout instead, provide
    `HELPSCOUT_API_KEY` and `HELPSCOUT_MAILBOX_ID` (optionally set
    `HELPSCOUT_SMTP_FALLBACK=true` to also send email).
-   ServiceNow integration has been removed. You can customize `API_PORT`,
-   `LOGO_URL` and other defaults.
+   **Note:** ServiceNow integration has been fully deprecated and removed.
+   You can customize `API_PORT`, `LOGO_URL` and other defaults.
 4. Start the server with `node index.js` (uses `API_PORT`, default `3000`).
 
 The API also exposes a GraphQL endpoint at `/api/v2/graphql` for internal tools.
@@ -293,7 +293,8 @@ want the server to also send the ticket email using your SMTP configuration.
 
 ## ServiceNow Integration (Deprecated)
 
-ServiceNow support has been removed from the platform.
+ServiceNow support has been **removed** from the platform and no
+ServiceNow-specific configuration or endpoints remain.
 
 ## Kiosk Activation
 

--- a/apps/core/nova-core/src/lib/mockData.ts
+++ b/apps/core/nova-core/src/lib/mockData.ts
@@ -120,8 +120,7 @@ export const mockLogs: Log[] = [
     system: 'Desktop',
     urgency: 'Medium',
     timestamp: new Date().toISOString(),
-    emailStatus: 'success',
-    serviceNowId: 'INC0010001'
+    emailStatus: 'success'
   },
   {
     id: 2,
@@ -132,8 +131,7 @@ export const mockLogs: Log[] = [
     system: 'Laptop',
     urgency: 'Critical',
     timestamp: new Date(Date.now() - 1800000).toISOString(), // 30 minutes ago
-    emailStatus: 'success',
-    serviceNowId: 'INC0010002'
+    emailStatus: 'success'
   }
 ];
 

--- a/apps/core/nova-core/src/types/index.d.ts
+++ b/apps/core/nova-core/src/types/index.d.ts
@@ -80,7 +80,6 @@ export interface Log {
     urgency: 'Low' | 'Medium' | 'High' | 'Critical';
     timestamp: string;
     emailStatus: 'success' | 'fail';
-    serviceNowId?: string;
 }
 export interface Config {
     logoUrl: string;

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -96,7 +96,6 @@ export interface Log {
   urgency: 'Low' | 'Medium' | 'High' | 'Critical';
   timestamp: string;
   emailStatus: 'success' | 'fail';
-  serviceNowId?: string;
 }
 
 export interface Config {

--- a/docs/Feature_Inventory.md
+++ b/docs/Feature_Inventory.md
@@ -63,7 +63,7 @@ This document provides a comprehensive inventory of features, modules, and submo
 
 ### Integrations
 - **Slack**: Slash commands and notifications.
-- **ServiceNow**: ~~Incident creation (deprecated)~~
+ - **ServiceNow**: ~~Integration deprecated and removed~~
 - **HelpScout**: Ticket synchronization.
 
 ### Knowledge Base

--- a/docs/Missing_Endpoints_Plan.md
+++ b/docs/Missing_Endpoints_Plan.md
@@ -14,9 +14,9 @@ This document outlines the missing API endpoints required for the Nova-Universe 
 - **Priority**: High
 
 ### ServiceNow Integration
-- **Description**: Remove ServiceNow integration.
-- **Endpoints to Remove**:
-  - `POST /api/servicenow/create` – Create incidents in ServiceNow.
+- **Description**: ServiceNow integration has been deprecated and all related
+  endpoints have been removed.
+- **Endpoints to Remove**: N/A
 - **Priority**: High
 
 ### Advanced Reporting and Analytics

--- a/docs/Missing_Endpoints_Plan.md
+++ b/docs/Missing_Endpoints_Plan.md
@@ -16,7 +16,7 @@ This document outlines the missing API endpoints required for the Nova-Universe 
 ### ServiceNow Integration
 - **Description**: ServiceNow integration has been deprecated and all related
   endpoints have been removed.
-- **Endpoints to Remove**: N/A
+- **Status**: Completed. All ServiceNow-related endpoints have been removed.
 - **Priority**: High
 
 ### Advanced Reporting and Analytics

--- a/docs/README.md
+++ b/docs/README.md
@@ -70,7 +70,7 @@ Express.js backend with PostgreSQL database. Handles ticket submission, user man
 - PostgreSQL database with automatic migrations
 - Comprehensive security middleware
 - Rate limiting and input validation
-- Integration with HelpScout and Slack (ServiceNow integration deprecated)
+- Integration with HelpScout and Slack (ServiceNow integration removed)
 
 ### nova-admin
 React admin interface for managing the help desk system.


### PR DESCRIPTION
## Summary
- strip `serviceNowId` mock data and interfaces
- clarify that ServiceNow integration has been fully removed

## Testing
- `npm install`
- `npm test` *(fails: Jest config validation error)*

------
https://chatgpt.com/codex/tasks/task_e_6887d3ffdcd08333b690834f9795e391