### PR TITLE
Implement Pulse endpoints and pages

### DIFF
--- a/apps/api/middleware/queueAccess.js
+++ b/apps/api/middleware/queueAccess.js
@@ -1,0 +1,15 @@
+export function checkQueueAccess(queueGetter) {
+  return (req, res, next) => {
+    const queue = typeof queueGetter === 'function' ? queueGetter(req) : queueGetter
+    const user = req.user || {}
+    const { queues = [], roles = [] } = user
+
+    if (roles.includes('admin') || roles.includes('superadmin') || queues.includes(queue)) {
+      return next()
+    }
+    return res.status(403).json({
+      error: 'Insufficient queue permissions',
+      errorCode: 'QUEUE_ACCESS_DENIED'
+    })
+  }
+}

--- a/apps/api/middleware/queueAccess.js
+++ b/apps/api/middleware/queueAccess.js
@@ -4,7 +4,10 @@ export function checkQueueAccess(queueGetter) {
     const user = req.user || {}
     const { queues = [], roles = [] } = user
 
-    if (roles.includes('admin') || roles.includes('superadmin') || queues.includes(queue)) {
+    if (roles.includes('admin') || roles.includes('superadmin')) {
+      return next()
+    }
+    if (queue && queues.includes(queue)) {
       return next()
     }
     return res.status(403).json({

--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -6,6 +6,7 @@ import db from '../db.js';
 import { logger } from '../logger.js';
 import { authenticateJWT } from '../middleware/auth.js';
 import { createRateLimit } from '../middleware/rateLimiter.js';
+import { checkQueueAccess } from '../middleware/queueAccess.js';
 
 const router = express.Router();
 
@@ -345,6 +346,7 @@ router.get('/dashboard',
  */
 router.get('/tickets',
   authenticateJWT,
+  checkQueueAccess(req => req.query.queue),
   createRateLimit(15 * 60 * 1000, 100), // 100 requests per 15 minutes
   async (req, res) => {
     try {
@@ -406,7 +408,7 @@ router.get('/tickets',
           });
         }
 
-        const tickets = (rows || []).map(row => ({
+        let tickets = (rows || []).map(row => ({
           id: row.id,
           ticketId: row.ticket_id,
           title: row.title,
@@ -429,8 +431,13 @@ router.get('/tickets',
           },
           createdAt: row.created_at,
           updatedAt: row.updated_at,
-          dueDate: row.due_date
+          dueDate: row.due_date,
+          slaRemaining: row.due_date ?
+            Math.round((new Date(row.due_date) - Date.now()) / 60000) : null,
+          vipWeight: row.vip_weight || 0
         }));
+
+        tickets = tickets.sort((a, b) => b.vipWeight - a.vipWeight);
 
         const total = rows.length > 0 ? rows[0].total_count : 0;
         const hasMore = parseInt(offset) + parseInt(limit) < total;
@@ -826,6 +833,52 @@ router.get('/timesheet',
         error: 'Failed to fetch timesheet',
         errorCode: 'TIMESHEET_ERROR'
       });
+    }
+  }
+);
+
+// Alerts feed - proxies Nova Core alerts
+router.get('/alerts',
+  authenticateJWT,
+  checkQueueAccess(req => req.query.queue),
+  async (req, res) => {
+    try {
+      const alerts = await db.findDocuments('alerts', { queue: req.query.queue })
+      res.json({ success: true, alerts })
+    } catch (err) {
+      logger.error('Error fetching alerts:', err)
+      res.status(500).json({ success: false, error: 'Failed to fetch alerts', errorCode: 'ALERTS_ERROR' })
+    }
+  }
+);
+
+// Inventory lookup
+router.get('/inventory',
+  authenticateJWT,
+  checkQueueAccess(req => req.query.queue),
+  async (req, res) => {
+    try {
+      const assets = await db.findDocuments('assets', {})
+      res.json({ success: true, assets })
+    } catch (err) {
+      logger.error('Error fetching inventory:', err)
+      res.status(500).json({ success: false, error: 'Failed to fetch inventory', errorCode: 'INVENTORY_ERROR' })
+    }
+  }
+);
+
+// XP event logging
+router.post('/xp',
+  authenticateJWT,
+  async (req, res) => {
+    try {
+      const { amount = 0, reason } = req.body
+      await db.run('INSERT INTO xp_events (user_id, amount, reason, created_at) VALUES ($1, $2, $3, $4)',
+        [req.user.id, amount, reason || null, new Date().toISOString()])
+      res.json({ success: true })
+    } catch (err) {
+      logger.error('Error logging XP event:', err)
+      res.status(500).json({ success: false, error: 'Failed to record XP', errorCode: 'XP_ERROR' })
     }
   }
 );

--- a/apps/pulse/nova-pulse/src/App.tsx
+++ b/apps/pulse/nova-pulse/src/App.tsx
@@ -6,6 +6,8 @@ import { TicketsPage } from './pages/TicketsPage'
 import { DeepWorkPage } from './pages/DeepWorkPage'
 import { GamificationPage } from './pages/GamificationPage'
 import { AlertsPage } from './pages/AlertsPage'
+import { InventoryPage } from './pages/InventoryPage'
+import { LeaderboardPage } from './pages/LeaderboardPage'
 
 const queryClient = new QueryClient({
   defaultOptions: { queries: { refetchOnWindowFocus: false } }
@@ -19,6 +21,8 @@ const App: React.FC = () => (
         <Route path="/tickets" element={<TicketsPage />} />
         <Route path="/tickets/:ticketId" element={<DeepWorkPage />} />
         <Route path="/alerts" element={<AlertsPage />} />
+        <Route path="/inventory" element={<InventoryPage />} />
+        <Route path="/leaderboard" element={<LeaderboardPage />} />
         <Route path="/gamification" element={<GamificationPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate } from '../types'
+import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate, Alert, Asset, XpEvent } from '../types'
 
 const client = axios.create({ baseURL: '/api/v1/pulse' })
 
@@ -21,4 +21,19 @@ export const updateTicket = async (ticketId: string, updates: TicketUpdate) => {
 export const getTimesheet = async (params?: Record<string, string>) => {
   const { data } = await client.get<{ success: boolean; timesheet: TimesheetEntry[] }>('/timesheet', { params })
   return data.timesheet
+}
+
+export const getAlerts = async (params?: Record<string, string>) => {
+  const { data } = await client.get<{ success: boolean; alerts: Alert[] }>('/alerts', { params })
+  return data.alerts
+}
+
+export const getInventory = async () => {
+  const { data } = await client.get<{ success: boolean; assets: Asset[] }>('/inventory')
+  return data.assets
+}
+
+export const postXpEvent = async (event: Partial<XpEvent>) => {
+  const { data } = await client.post('/xp', event)
+  return data
 }

--- a/apps/pulse/nova-pulse/src/pages/AlertsPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/AlertsPage.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { AlertsFeed } from '../components/AlertsFeed'
+import { useQuery } from '@tanstack/react-query'
+import { getAlerts } from '../lib/api'
 
-// Placeholder alerts until API route exists
-const sampleAlerts = [
-  { id: '1', message: 'Server CPU high', createdAt: new Date().toISOString() },
-  { id: '2', message: 'New security incident', createdAt: new Date().toISOString() }
-]
+export const AlertsPage: React.FC = () => {
+  const { data: alerts = [] } = useQuery({ queryKey: ['alerts'], queryFn: () => getAlerts() })
 
-export const AlertsPage: React.FC = () => (
-  <div>
-    <h2 className="text-xl font-semibold mb-4">Alerts</h2>
-    <AlertsFeed alerts={sampleAlerts} />
-  </div>
-)
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Alerts</h2>
+      <AlertsFeed alerts={alerts} />
+    </div>
+  )
+}
+

--- a/apps/pulse/nova-pulse/src/pages/InventoryPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/InventoryPage.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getInventory } from '../lib/api'
+
+export const InventoryPage: React.FC = () => {
+  const { data: assets = [] } = useQuery({ queryKey: ['inventory'], queryFn: getInventory })
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Inventory</h2>
+      <ul className="list-disc pl-5">
+        {assets.map(asset => (
+          <li key={asset.id}>{asset.name} - {asset.type}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/pages/LeaderboardPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/LeaderboardPage.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { useMutation } from '@tanstack/react-query'
+import { postXpEvent } from '../lib/api'
+
+export const LeaderboardPage: React.FC = () => {
+  const mutation = useMutation({ mutationFn: postXpEvent })
+
+  const awardXp = () => mutation.mutate({ amount: 10, reason: 'test' })
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Leaderboard</h2>
+      <button className="btn-primary" onClick={awardXp}>Award Test XP</button>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -10,6 +10,9 @@ export interface Ticket {
   assignedTo?: { id: number; name: string }
   createdAt: string
   updatedAt: string
+  dueDate?: string
+  slaRemaining?: number
+  vipWeight?: number
 }
 
 export interface TicketUpdate extends Partial<Ticket> {
@@ -38,4 +41,23 @@ export interface TimesheetEntry {
   title: string
   timeSpent: number
   date: string
+}
+
+export interface Alert {
+  id: string
+  message: string
+  createdAt: string
+}
+
+export interface Asset {
+  id: number
+  name: string
+  type: string
+  status?: string
+}
+
+export interface XpEvent {
+  amount: number
+  reason?: string
+  createdAt: string
 }


### PR DESCRIPTION
## Summary
- add queue-based RBAC middleware
- extend technician ticket query with VIP weighting and SLA timer
- add `/alerts`, `/inventory`, and `/xp` endpoints
- create Inventory and Leaderboard pages and update Alert page
- connect new pages in Pulse app
- expose client helpers for alerts, inventory and XP

## Testing
- `npm install`
- `npx jest --config apps/api/jest.config.ts` *(fails: Jest config parsing issues)*

------
https://chatgpt.com/codex/tasks/task_e_6887e12b71288333a53af9410055c46a