### PR TITLE
Fix undefined constants

### DIFF
--- a/apps/api/middleware/queueAccess.js
+++ b/apps/api/middleware/queueAccess.js
@@ -1,3 +1,5 @@
+const VALID_QUEUE_IDENTIFIER_REGEX = /^[A-Za-z0-9_-]+$/;
+
 export function checkQueueAccess(queueGetter) {
   return (req, res, next) => {
     const queue = typeof queueGetter === 'function' ? queueGetter(req) : queueGetter

--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -8,6 +8,9 @@ import { authenticateJWT } from '../middleware/auth.js';
 import { createRateLimit } from '../middleware/rateLimiter.js';
 import { checkQueueAccess } from '../middleware/queueAccess.js';
 
+// Maximum XP that can be awarded in a single event
+const MAX_XP_AMOUNT = 1000;
+
 const router = express.Router();
 
 /**


### PR DESCRIPTION
## Summary
- define `VALID_QUEUE_IDENTIFIER_REGEX`
- add `MAX_XP_AMOUNT` constant for /pulse/xp route

## Testing
- `pnpm install` *(fails: Could not install from workspace packages)*
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68886fcce0b083339f2c7e5054db2296