### PR TITLE
Fix asset assignment user id handling

### DIFF
--- a/apps/api/routes/inventory.js
+++ b/apps/api/routes/inventory.js
@@ -145,7 +145,7 @@ router.post('/:id/assign', authenticateJWT, async (req, res) => {
   try {
     let { user_id, org_id, customer_id, assigned_by, expected_return, manager_id } = req.body;
 
-    if (user_id == null || user_id === '') {
+    if (user_id === null || user_id === undefined || user_id === '') {
       user_id = null;
     }
     const { rows } = await db.query(

--- a/apps/api/routes/inventory.js
+++ b/apps/api/routes/inventory.js
@@ -143,7 +143,11 @@ router.post('/:id/status', authenticateJWT, async (req, res) => {
 // Create assignment
 router.post('/:id/assign', authenticateJWT, async (req, res) => {
   try {
-    const { user_id, org_id, customer_id, assigned_by, expected_return, manager_id } = req.body;
+    let { user_id, org_id, customer_id, assigned_by, expected_return, manager_id } = req.body;
+
+    if (user_id == null || user_id === '') {
+      user_id = null;
+    }
     const { rows } = await db.query(
       `INSERT INTO asset_assignments (asset_id, user_id, org_id, customer_id, assigned_by, expected_return, manager_id)
        VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`,


### PR DESCRIPTION
## Summary
- allow empty or missing `user_id` when creating asset assignments and treat it as `null`

## Testing
- `npm test` *(fails: extensionsToTreatAsEsm includes '.js')*
- `apps/api/npm test` *(fails: extensionsToTreatAsEsm includes '.js')*

------
https://chatgpt.com/codex/tasks/task_e_68887084e47883338cd705ddd6d66b89