### PR TITLE
Add XP leaderboard support

### DIFF
--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -888,7 +888,7 @@ router.get('/xp',
   async (req, res) => {
     try {
       const { rows } = await db.query(
-        'SELECT u.id, u.name, u.department, l.xp_total FROM leaderboard l JOIN users u ON u.id = l.user_id ORDER BY l.xp_total DESC LIMIT 20'
+        'SELECT u.id AS userId, u.name, u.department, l.xp_total FROM leaderboard l JOIN users u ON u.id = l.user_id ORDER BY l.xp_total DESC LIMIT 20'
       )
       const { rows: teamRows } = await db.query(
         'SELECT u.department AS team, SUM(l.xp_total) AS xp_total FROM leaderboard l JOIN users u ON l.user_id = u.id GROUP BY u.department ORDER BY xp_total DESC'

--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -891,7 +891,7 @@ router.get('/xp',
         'SELECT u.id AS userId, u.name, u.department, l.xp_total FROM leaderboard l JOIN users u ON u.id = l.user_id ORDER BY l.xp_total DESC LIMIT 20'
       )
       const { rows: teamRows } = await db.query(
-        'SELECT u.department AS team, SUM(l.xp_total) AS xp_total FROM leaderboard l JOIN users u ON l.user_id = u.id GROUP BY u.department ORDER BY xp_total DESC'
+        'SELECT u.department AS team, SUM(l.xp_total) AS xp_total FROM leaderboard l JOIN users u ON l.user_id = u.id GROUP BY u.department ORDER BY SUM(l.xp_total) DESC'
       )
       const myRes = await db.query('SELECT xp_total FROM leaderboard WHERE user_id = $1', [req.user.id])
       const myXp = myRes.rows[0] ? parseInt(myRes.rows[0].xp_total, 10) : 0

--- a/apps/pulse/nova-pulse/src/components/LeaderboardTable.tsx
+++ b/apps/pulse/nova-pulse/src/components/LeaderboardTable.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Table, TableHead, TableRow, TableCell, TableBody } from '@nova-universe/ui'
+import type { LeaderboardEntry } from '../types'
+
+interface Props {
+  leaderboard: LeaderboardEntry[]
+}
+
+export const LeaderboardTable: React.FC<Props> = ({ leaderboard }) => (
+  <Table className="min-w-full">
+    <TableHead>
+      <TableRow>
+        <TableCell>Rank</TableCell>
+        <TableCell>Name</TableCell>
+        <TableCell>XP</TableCell>
+      </TableRow>
+    </TableHead>
+    <TableBody>
+      {leaderboard.map((entry, idx) => (
+        <TableRow key={entry.userId}>
+          <TableCell>{idx + 1}</TableCell>
+          <TableCell>{entry.name}</TableCell>
+          <TableCell>{entry.xpTotal}</TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)

--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate, Alert, Asset, XpEvent } from '../types'
+import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate, Alert, Asset, XpEvent, LeaderboardEntry, TeamRanking } from '../types'
 
 const client = axios.create({ baseURL: '/api/v1/pulse' })
 
@@ -40,5 +40,10 @@ export const getAssetsForUser = async (userId: string) => {
 
 export const postXpEvent = async (event: Partial<XpEvent>) => {
   const { data } = await client.post('/xp', event)
+  return data
+}
+
+export const getXpLeaderboard = async () => {
+  const { data } = await client.get<{ success: boolean; leaderboard: LeaderboardEntry[]; teams: TeamRanking[]; me: { xp: number } }>('/xp')
   return data
 }

--- a/apps/pulse/nova-pulse/src/pages/GamificationPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/GamificationPage.tsx
@@ -1,8 +1,15 @@
 import React from 'react'
+import { useQuery } from '@tanstack/react-query'
+import { getXpLeaderboard } from '../lib/api'
 
-export const GamificationPage: React.FC = () => (
-  <div>
-    <h2 className="text-xl font-semibold mb-4">Gamification</h2>
-    <p>Track your Stardust XP and achievements here.</p>
-  </div>
-)
+export const GamificationPage: React.FC = () => {
+  const { data } = useQuery({ queryKey: ['xp', 'me'], queryFn: getXpLeaderboard })
+  const xp = data?.me?.xp || 0
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Gamification</h2>
+      <p>Your Stardust XP: {xp}</p>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/pages/LeaderboardPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/LeaderboardPage.tsx
@@ -1,16 +1,28 @@
 import React from 'react'
-import { useMutation } from '@tanstack/react-query'
-import { postXpEvent } from '../lib/api'
+import { useMutation, useQuery } from '@tanstack/react-query'
+import { postXpEvent, getXpLeaderboard } from '../lib/api'
+import { LeaderboardTable } from '../components/LeaderboardTable'
 
 export const LeaderboardPage: React.FC = () => {
   const mutation = useMutation({ mutationFn: postXpEvent })
+  const { data } = useQuery({ queryKey: ['leaderboard'], queryFn: getXpLeaderboard })
 
   const awardXp = () => mutation.mutate({ amount: 10, reason: 'test' })
+
+  const leaderboard = data?.leaderboard || []
+  const teams = data?.teams || []
 
   return (
     <div>
       <h2 className="text-xl font-semibold mb-4">Leaderboard</h2>
-      <button className="btn-primary" onClick={awardXp}>Award Test XP</button>
+      <LeaderboardTable leaderboard={leaderboard} />
+      <h3 className="text-lg font-semibold mt-6">Team Rankings</h3>
+      <ul className="list-disc pl-5">
+        {teams.map(t => (
+          <li key={t.team}>{t.team || 'Unassigned'} - {t.xpTotal} XP</li>
+        ))}
+      </ul>
+      <button className="btn-primary mt-4" onClick={awardXp}>Award Test XP</button>
     </div>
   )
 }

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -64,3 +64,15 @@ export interface XpEvent {
   reason?: string
   createdAt: string
 }
+
+export interface LeaderboardEntry {
+  userId: string
+  name: string
+  department?: string
+  xpTotal: number
+}
+
+export interface TeamRanking {
+  team: string | null
+  xpTotal: number
+}

--- a/packages/database/database/schema.sql
+++ b/packages/database/database/schema.sql
@@ -33,7 +33,7 @@ CREATE TABLE audit_logs (
 -- XP Events Table
 CREATE TABLE xp_events (
     id SERIAL PRIMARY KEY,
-    user_id INT REFERENCES users(id),
+    user_id TEXT REFERENCES users(id),
     amount INT NOT NULL,
     reason TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/packages/database/database/schema.sql
+++ b/packages/database/database/schema.sql
@@ -41,6 +41,6 @@ CREATE TABLE xp_events (
 
 -- Leaderboard Table
 CREATE TABLE leaderboard (
-    user_id INT PRIMARY KEY REFERENCES users(id),
+    user_id TEXT PRIMARY KEY REFERENCES users(id),
     xp_total INT NOT NULL DEFAULT 0
 );

--- a/packages/database/database/schema.sql
+++ b/packages/database/database/schema.sql
@@ -29,3 +29,18 @@ CREATE TABLE audit_logs (
     ticket_id INT REFERENCES tickets(id),
     timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+-- XP Events Table
+CREATE TABLE xp_events (
+    id SERIAL PRIMARY KEY,
+    user_id INT REFERENCES users(id),
+    amount INT NOT NULL,
+    reason TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Leaderboard Table
+CREATE TABLE leaderboard (
+    user_id INT PRIMARY KEY REFERENCES users(id),
+    xp_total INT NOT NULL DEFAULT 0
+);

--- a/prisma/migrations/20250729000000_add_xp_tables/migration.sql
+++ b/prisma/migrations/20250729000000_add_xp_tables/migration.sql
@@ -1,0 +1,18 @@
+-- Add XP events and leaderboard tables
+
+CREATE TABLE "xp_events" (
+  "id" SERIAL NOT NULL,
+  "user_id" TEXT NOT NULL,
+  "amount" INTEGER NOT NULL,
+  "reason" TEXT,
+  "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "xp_events_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "xp_events" ADD CONSTRAINT "xp_events_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+CREATE TABLE "leaderboard" (
+  "user_id" TEXT NOT NULL PRIMARY KEY,
+  "xp_total" INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "leaderboard_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -311,3 +311,22 @@ model AssetAssignment {
 
   @@map("asset_assignments")
 }
+
+model XpEvent {
+  id        Int      @id @default(autoincrement())
+  userId    String   @map("user_id")
+  amount    Int
+  reason    String?
+  createdAt DateTime @default(now()) @map("created_at")
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("xp_events")
+}
+
+model Leaderboard {
+  userId  String @id @map("user_id")
+  xpTotal Int    @default(0) @map("xp_total")
+  user    User   @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("leaderboard")
+}


### PR DESCRIPTION
## Summary
- create new XP tables
- expose `/pulse/xp` GET for leaderboard rankings
- update XP event posting to sync leaderboard
- implement leaderboard and gamification UI

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_6888dd37a5c88333ab118346ab7f2635