### PR TITLE
Implement reports and workflows endpoints

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -9,6 +9,8 @@ import rolesRouter from './routes/roles.js';
 import searchRouter from './routes/search.js';
 import serverRouter from './routes/server.js';
 import logsRouter from './routes/logs.js'; // Import logsRouter
+import reportsRouter from './routes/reports.js';
+import workflowsRouter from './routes/workflows.js';
 // Nova module routes
 import { Strategy as SamlStrategy } from '@node-saml/passport-saml';
 import {
@@ -1211,6 +1213,8 @@ app.use('/api/v1/search', searchRouter);
 app.use('/api/v1/configuration', configurationRouter);
 app.use('/api/v1', serverRouter); // Handles /api/v1/server-info
 app.use('/api/v1/logs', logsRouter); // Register logsRouter
+app.use('/api/reports', reportsRouter);
+app.use('/api/workflows', workflowsRouter);
 
 // Nova module routes
 app.use('/api/v1/helix', helixRouter);     // Nova Helix - Identity Engine

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -4,16 +4,10 @@ const config: JestConfigWithTsJest = {
   verbose: true,
   testEnvironment: 'node',
   transform: {
-    '^.+\\.ts$': [
-      'ts-jest',
-      { useESM: true }
-    ],
-    '^.+\\.js$': [
-      'babel-jest',
-      { useESM: true }
-    ]
+    '^.+\\.ts$': 'ts-jest',
+    '^.+\\.js$': 'babel-jest'
   },
-  extensionsToTreatAsEsm: ['.ts', '.js', '.mjs'],
+  extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },

--- a/apps/api/openapi_spec.yaml
+++ b/apps/api/openapi_spec.yaml
@@ -155,6 +155,93 @@ paths:
                   id:
                     type: string
 
+  /api/reports/usage:
+    get:
+      summary: Get usage metrics
+      responses:
+        '200':
+          description: Usage metrics
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  users:
+                    type: integer
+                  kiosks:
+                    type: integer
+                  timestamp:
+                    type: string
+                    format: date-time
+
+  /api/reports/insights:
+    get:
+      summary: Get system insights
+      responses:
+        '200':
+          description: Insights list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    message:
+                      type: string
+
+  /api/workflows/trigger:
+    post:
+      summary: Trigger a workflow
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workflow:
+                  type: string
+      responses:
+        '200':
+          description: Workflow triggered
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  runId:
+                    type: integer
+                  status:
+                    type: string
+        '400':
+          description: Missing workflow
+
+  /api/workflows/status:
+    get:
+      summary: Get workflow status
+      responses:
+        '200':
+          description: Workflow status list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    workflow:
+                      type: string
+                    status:
+                      type: string
+                    triggeredAt:
+                      type: string
+                      format: date-time
+
 components:
   securitySchemes:
     bearerAuth:

--- a/apps/api/routes/reports.js
+++ b/apps/api/routes/reports.js
@@ -1,0 +1,71 @@
+import express from 'express';
+import db from '../db.js';
+
+const router = express.Router();
+
+// Mock insights data
+const insights = [
+  { id: 1, message: 'User activity steady' },
+  { id: 2, message: 'Most logins occur on Monday' }
+];
+
+/**
+ * @swagger
+ * /api/reports/usage:
+ *   get:
+ *     summary: Get basic usage metrics
+ *     responses:
+ *       200:
+ *         description: Usage metrics object
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 users:
+ *                   type: integer
+ *                 kiosks:
+ *                   type: integer
+ *                 timestamp:
+ *                   type: string
+ *                   format: date-time
+ */
+router.get('/usage', async (req, res) => {
+  try {
+    const { rows: userRows } = await db.query('SELECT COUNT(*) AS count FROM users');
+    const { rows: kioskRows } = await db.query('SELECT COUNT(*) AS count FROM kiosks');
+    res.json({
+      users: parseInt(userRows[0].count, 10),
+      kiosks: parseInt(kioskRows[0].count, 10),
+      timestamp: new Date().toISOString()
+    });
+  } catch (err) {
+    res.status(500).json({ error: 'Database error', errorCode: 'DB_ERROR' });
+  }
+});
+
+/**
+ * @swagger
+ * /api/reports/insights:
+ *   get:
+ *     summary: Get system insights
+ *     responses:
+ *       200:
+ *         description: List of insights
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   message:
+ *                     type: string
+ */
+router.get('/insights', (req, res) => {
+  res.json(insights);
+});
+
+export default router;

--- a/apps/api/routes/workflows.js
+++ b/apps/api/routes/workflows.js
@@ -1,0 +1,79 @@
+import express from 'express';
+
+const router = express.Router();
+const runs = [];
+
+/**
+ * @swagger
+ * /api/workflows/trigger:
+ *   post:
+ *     summary: Trigger a workflow
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               workflow:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Workflow triggered
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 runId:
+ *                   type: integer
+ *                 status:
+ *                   type: string
+ *       400:
+ *         description: Missing workflow id
+ */
+router.post('/trigger', (req, res) => {
+  const { workflow } = req.body || {};
+  if (!workflow) {
+    return res.status(400).json({ error: 'Missing workflow' });
+  }
+  const id = runs.length + 1;
+  const record = { id, workflow, status: 'queued', triggeredAt: new Date().toISOString() };
+  runs.push(record);
+  res.json({ runId: id, status: record.status });
+});
+
+/**
+ * @swagger
+ * /api/workflows/status:
+ *   get:
+ *     summary: Get workflow status
+ *     responses:
+ *       200:
+ *         description: List of workflow runs
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   id:
+ *                     type: integer
+ *                   workflow:
+ *                     type: string
+ *                   status:
+ *                     type: string
+ *                   triggeredAt:
+ *                     type: string
+ *                     format: date-time
+ */
+router.get('/status', (req, res) => {
+  res.json(runs);
+});
+
+export function resetWorkflowRuns() {
+  runs.length = 0;
+}
+
+export default router;

--- a/apps/api/test/reports-workflows.test.js
+++ b/apps/api/test/reports-workflows.test.js
@@ -1,0 +1,46 @@
+import 'dotenv/config';
+import request from 'supertest';
+import assert from 'assert';
+import setupPromise from './00_setup.js';
+import { resetWorkflowRuns } from '../routes/workflows.js';
+
+let app;
+
+beforeAll(async () => {
+  await setupPromise;
+  app = global.app;
+});
+
+beforeEach(() => {
+  resetWorkflowRuns();
+});
+
+describe('Reports API', () => {
+  test('GET /api/reports/usage', async () => {
+    const res = await request(app).get('/api/reports/usage').expect(200);
+    assert.ok(typeof res.body.users === 'number');
+    assert.ok(typeof res.body.kiosks === 'number');
+  });
+
+  test('GET /api/reports/insights', async () => {
+    const res = await request(app).get('/api/reports/insights').expect(200);
+    assert.ok(Array.isArray(res.body));
+  });
+});
+
+describe('Workflows API', () => {
+  test('trigger and fetch status', async () => {
+    const tr = await request(app)
+      .post('/api/workflows/trigger')
+      .send({ workflow: 'test-flow' })
+      .expect(200);
+    assert.ok(tr.body.runId);
+    const st = await request(app).get('/api/workflows/status').expect(200);
+    assert.strictEqual(st.body.length, 1);
+    assert.strictEqual(st.body[0].workflow, 'test-flow');
+  });
+
+  test('missing workflow returns 400', () => {
+    return request(app).post('/api/workflows/trigger').send({}).expect(400);
+  });
+});


### PR DESCRIPTION
## Summary
- add /reports and /workflows routes
- mount new routers in API app
- document new endpoints in OpenAPI spec
- tweak Jest config for ESM
- create minimal tests for new endpoints

## Testing
- `node --experimental-vm-modules node_modules/jest/bin/jest.js --config apps/api/jest.config.ts apps/api/test/reports-workflows.test.js` *(fails: ReferenceError: You are trying to `import` a file after the Jest environment has been torn down)*

------
https://chatgpt.com/codex/tasks/task_e_6889141b85c4833386f8770e49715aa3