### PR TITLE
Improve DeepWorkPage with history, related items & Cosmo

### DIFF
--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -886,7 +886,16 @@ router.get('/inventory',
 // Ticket history
 router.get('/tickets/:ticketId/history',
   authenticateJWT,
+  [
+    body('ticketId')
+      .isNumeric().withMessage('Ticket ID must be a numeric value')
+      .notEmpty().withMessage('Ticket ID is required'),
+  ],
   async (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ success: false, errors: errors.array() });
+    }
     try {
       const { ticketId } = req.params;
       db.all(`

--- a/apps/api/routes/pulse.js
+++ b/apps/api/routes/pulse.js
@@ -883,6 +883,87 @@ router.get('/inventory',
   }
 );
 
+// Ticket history
+router.get('/tickets/:ticketId/history',
+  authenticateJWT,
+  async (req, res) => {
+    try {
+      const { ticketId } = req.params;
+      db.all(`
+        SELECT tl.action, tl.details, tl.timestamp, u.name as user_name
+        FROM ticket_logs tl
+        LEFT JOIN users u ON tl.user_id = u.id
+        WHERE tl.ticket_id = $1
+        ORDER BY tl.timestamp ASC
+      `, [ticketId], (err, rows) => {
+        if (err) {
+          logger.error('Error fetching ticket history:', err);
+          return res.status(500).json({ success: false, error: 'Failed to fetch ticket history', errorCode: 'HISTORY_ERROR' });
+        }
+        const history = (rows || []).map(r => ({
+          action: r.action,
+          details: r.details,
+          timestamp: r.timestamp,
+          user: r.user_name
+        }));
+        res.json({ success: true, history });
+      });
+    } catch (error) {
+      logger.error('Error fetching ticket history:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch ticket history', errorCode: 'HISTORY_ERROR' });
+    }
+  }
+);
+
+// Related items for a ticket
+router.get('/tickets/:ticketId/related',
+  authenticateJWT,
+  async (req, res) => {
+    try {
+      const { ticketId } = req.params;
+      db.get('SELECT requested_by_id FROM tickets WHERE ticket_id = $1', [ticketId], (err, ticket) => {
+        if (err) {
+          logger.error('Error fetching ticket:', err);
+          return res.status(500).json({ success: false, error: 'Failed to fetch related items', errorCode: 'RELATED_ERROR' });
+        }
+        if (!ticket) {
+          return res.status(404).json({ success: false, error: 'Ticket not found', errorCode: 'TICKET_NOT_FOUND' });
+        }
+
+        db.all(`
+          SELECT ticket_id, title, status, priority
+          FROM tickets
+          WHERE requested_by_id = $1 AND ticket_id != $2 AND deleted_at IS NULL
+          ORDER BY created_at DESC
+          LIMIT 5
+        `, [ticket.requested_by_id, ticketId], (relErr, relatedTickets) => {
+          if (relErr) {
+            logger.error('Error fetching related tickets:', relErr);
+            return res.status(500).json({ success: false, error: 'Failed to fetch related items', errorCode: 'RELATED_ERROR' });
+          }
+
+          db.all(`
+            SELECT id, name, asset_tag
+            FROM inventory_assets
+            WHERE assigned_to_user_id = $1
+            LIMIT 5
+          `, [ticket.requested_by_id], (assetErr, assets) => {
+            if (assetErr) {
+              logger.error('Error fetching related assets:', assetErr);
+              return res.status(500).json({ success: false, error: 'Failed to fetch related items', errorCode: 'RELATED_ERROR' });
+            }
+
+            res.json({ success: true, tickets: relatedTickets || [], assets: assets || [] });
+          });
+        });
+      });
+    } catch (error) {
+      logger.error('Error fetching related items:', error);
+      res.status(500).json({ success: false, error: 'Failed to fetch related items', errorCode: 'RELATED_ERROR' });
+    }
+  }
+);
+
 // Get XP leaderboard and user totals
 router.get('/xp',
   authenticateJWT,

--- a/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
+++ b/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+import { Button } from '@nova-universe/ui'
+
+export const CosmoAssistant: React.FC = () => {
+  const [messages, setMessages] = useState<{ from: string; text: string }[]>([])
+  const [input, setInput] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSend = async () => {
+    if (!input.trim()) return
+    setLoading(true)
+    setMessages(msgs => [...msgs, { from: 'user', text: input }])
+    // TODO: integrate real Cosmo SDK
+    setTimeout(() => {
+      setMessages(msgs => [...msgs, { from: 'cosmo', text: 'This is a placeholder response from Cosmo.' }])
+      setLoading(false)
+    }, 1000)
+    setInput('')
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="border rounded bg-muted p-3 h-64 overflow-y-auto flex flex-col gap-2">
+        {messages.length === 0 && <div className="text-muted-foreground">Start a conversation with Cosmo...</div>}
+        {messages.map((m, i) => (
+          <div key={i} className={m.from === 'user' ? 'text-right' : 'text-left'}>
+            <span className={m.from === 'user' ? 'bg-primary text-primary-foreground' : 'bg-secondary text-secondary-foreground'} style={{ borderRadius: 8, padding: 8, display: 'inline-block', maxWidth: '80%' }}>{m.text}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2">
+        <input
+          className="flex-1 border rounded px-2 py-1"
+          placeholder="Ask Cosmo..."
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && handleSend()}
+          disabled={loading}
+        />
+        <Button onClick={handleSend} disabled={loading || !input.trim()}>Send</Button>
+      </div>
+    </div>
+  )
+}

--- a/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
+++ b/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
@@ -14,7 +14,7 @@ export const CosmoAssistant: React.FC = () => {
     setTimeout(() => {
       setMessages(msgs => [...msgs, { from: 'cosmo', text: 'This is a placeholder response from Cosmo.' }])
       setLoading(false)
-    }, 1000)
+    }, RESPONSE_DELAY)
     setInput('')
   }
 

--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate, Alert, Asset, XpEvent, LeaderboardEntry, TeamRanking } from '../types'
+import type { Ticket, DashboardData, TimesheetEntry, TicketUpdate, Alert, Asset, XpEvent, LeaderboardEntry, TeamRanking, TicketHistoryEntry } from '../types'
 
 const client = axios.create({ baseURL: '/api/v1/pulse' })
 
@@ -36,6 +36,16 @@ export const getInventory = async () => {
 export const getAssetsForUser = async (userId: string) => {
   const { data } = await client.get<{ success: boolean; assets: Asset[] }>(`/inventory/user/${userId}`)
   return data.assets
+}
+
+export const getTicketHistory = async (ticketId: string) => {
+  const { data } = await client.get<{ success: boolean; history: TicketHistoryEntry[] }>(`/tickets/${ticketId}/history`)
+  return data.history
+}
+
+export const getRelatedItems = async (ticketId: string) => {
+  const { data } = await client.get<{ success: boolean; tickets: Ticket[]; assets: Asset[] }>(`/tickets/${ticketId}/related`)
+  return { tickets: data.tickets, assets: data.assets }
 }
 
 export const postXpEvent = async (event: Partial<XpEvent>) => {

--- a/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
@@ -1,41 +1,150 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import { getTickets, updateTicket, getAssetsForUser } from '../lib/api'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { Tabs, Button } from '@nova-universe/ui'
+import { getTickets, updateTicket, getAssetsForUser, getTicketHistory, getRelatedItems } from '../lib/api'
+import type { TicketHistoryEntry } from '../types'
+import { CosmoAssistant } from '../components/CosmoAssistant'
 
 export const DeepWorkPage: React.FC = () => {
+  const queryClient = useQueryClient()
   const { ticketId } = useParams<{ ticketId: string }>()
-  const { data } = useQuery({ queryKey: ['ticket', ticketId], queryFn: () => getTickets({ ticketId }).then(t => t[0]), enabled: !!ticketId })
+  const { data, refetch } = useQuery({ queryKey: ['ticket', ticketId], queryFn: () => getTickets({ ticketId }).then(t => t[0]), enabled: !!ticketId })
   const { data: assets = [] } = useQuery({
     queryKey: ['ticketAssets', data?.requestedBy.id],
     queryFn: () => getAssetsForUser(data!.requestedBy.id),
     enabled: !!data
   })
+  const { data: history = [] } = useQuery({
+    queryKey: ['ticketHistory', ticketId],
+    queryFn: () => getTicketHistory(ticketId!),
+    enabled: !!ticketId
+  })
+  const { data: related } = useQuery({
+    queryKey: ['ticketRelated', ticketId],
+    queryFn: () => getRelatedItems(ticketId!),
+    enabled: !!ticketId
+  })
   const [note, setNote] = React.useState('')
+  const [status, setStatus] = React.useState<string>()
 
   if (!data) return <div>Loading...</div>
+
+  React.useEffect(() => {
+    setStatus(data.status)
+  }, [data.status])
 
   const handleUpdate = async () => {
     await updateTicket(ticketId!, { workNote: note })
     setNote('')
+    refetch()
+    queryClient.invalidateQueries({ queryKey: ['ticketHistory', ticketId] })
+  }
+
+  const handleStatusSave = async () => {
+    if (!status || status === data.status) return
+    await updateTicket(ticketId!, { status })
+    refetch()
+    queryClient.invalidateQueries({ queryKey: ['ticketHistory', ticketId] })
+  }
+
+  const toggleSla = async () => {
+    const newStatus = data.status === 'on_hold' ? 'in_progress' : 'on_hold'
+    await updateTicket(ticketId!, { status: newStatus })
+    refetch()
+    queryClient.invalidateQueries({ queryKey: ['ticketHistory', ticketId] })
   }
 
   return (
     <div className="space-y-4">
       <h2 className="text-xl font-semibold">{data.title}</h2>
-      <p>Status: {data.status}</p>
-      {assets.length > 0 && (
+      <div className="flex items-center gap-2">
+        <select value={status} onChange={e => setStatus(e.target.value)} className="border rounded px-2 py-1">
+          {['open', 'in_progress', 'on_hold', 'resolved', 'closed'].map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+        <Button size="sm" onClick={handleStatusSave}>Save</Button>
+        <Button variant="secondary" size="sm" onClick={toggleSla}>{data.status === 'on_hold' ? 'Resume SLA' : 'Pause SLA'}</Button>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4">
         <div>
-          <h3 className="font-semibold">Linked Assets</h3>
-          <ul className="list-disc pl-5">
-            {assets.map(a => (
-              <li key={a.id}>{a.name} ({a.assetTag || 'n/a'})</li>
-            ))}
-          </ul>
+          <h3 className="font-semibold mb-1">Requestor</h3>
+          <p>{data.requestedBy.name}</p>
+          <p className="text-sm text-muted-foreground">{data.requestedBy.email}</p>
         </div>
-      )}
+        <div>
+          <h3 className="font-semibold mb-1">Linked Assets</h3>
+          {assets.length === 0 ? <p className="text-sm text-muted-foreground">None</p> : (
+            <ul className="list-disc pl-5 text-sm">
+              {assets.map(a => (
+                <li key={a.id}>{a.name} ({a.assetTag || 'n/a'})</li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <CosmoAssistant />
+      </div>
+
+      <Tabs
+        tabs={[
+          {
+            label: 'Timeline',
+            content: (
+              <ul className="list-disc pl-5 space-y-1 text-sm">
+                {history.map((h: TicketHistoryEntry, i: number) => (
+                  <li key={i}>{new Date(h.timestamp).toLocaleString()} - {h.user}: {h.action} {h.details ? `- ${h.details}` : ''}</li>
+                ))}
+              </ul>
+            )
+          },
+          {
+            label: 'Related',
+            content: (
+              <div className="space-y-4 text-sm">
+                <div>
+                  <h4 className="font-semibold">Related Tickets</h4>
+                  <ul className="list-disc pl-5">
+                    {(related?.tickets || []).map(t => (
+                      <li key={t.ticketId}>{t.title} ({t.status})</li>
+                    ))}
+                  </ul>
+                </div>
+                <div>
+                  <h4 className="font-semibold">Org Assets</h4>
+                  <ul className="list-disc pl-5">
+                    {(related?.assets || []).map(a => (
+                      <li key={a.id}>{a.name} ({a.assetTag || 'n/a'})</li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )
+          },
+          {
+            label: 'Logs',
+            content: (
+              <pre className="bg-muted p-2 rounded text-xs overflow-auto max-h-64">
+                {history.map(h => `${h.timestamp} ${h.user} ${h.action} ${h.details || ''}`).join('\n')}
+              </pre>
+            )
+          },
+          {
+            label: 'Assets',
+            content: (
+              <ul className="list-disc pl-5 text-sm">
+                {assets.map(a => (
+                  <li key={a.id}>{a.name} ({a.assetTag || 'n/a'})</li>
+                ))}
+              </ul>
+            )
+          }
+        ]}
+      />
+
       <textarea value={note} onChange={e => setNote(e.target.value)} className="w-full border" />
-      <button className="btn-primary" onClick={handleUpdate}>Add Note</button>
+      <Button onClick={handleUpdate}>Add Note</Button>
     </div>
   )
 }

--- a/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
+++ b/apps/pulse/nova-pulse/src/pages/DeepWorkPage.tsx
@@ -123,13 +123,6 @@ export const DeepWorkPage: React.FC = () => {
             )
           },
           {
-            label: 'Logs',
-            content: (
-              <pre className="bg-muted p-2 rounded text-xs overflow-auto max-h-64">
-                {history.map(h => `${h.timestamp} ${h.user} ${h.action} ${h.details || ''}`).join('\n')}
-              </pre>
-            )
-          },
           {
             label: 'Assets',
             content: (

--- a/apps/pulse/nova-pulse/src/types.ts
+++ b/apps/pulse/nova-pulse/src/types.ts
@@ -59,6 +59,13 @@ export interface Asset {
   status?: string
 }
 
+export interface TicketHistoryEntry {
+  action: string
+  details?: string
+  timestamp: string
+  user: string
+}
+
 export interface XpEvent {
   amount: number
   reason?: string


### PR DESCRIPTION
## Summary
- enhance Pulse DeepWork view with tabs for ticket info
- fetch ticket history and related items via new endpoints
- add Cosmo assistant chat widget
- allow inline status updates and SLA pause/resume
- expose new Pulse API endpoints

## Testing
- `npm install`
- `npm test` *(fails: Validation Error in Jest config)*

------
https://chatgpt.com/codex/tasks/task_e_688931de664083339ab7f5aea646407d