### PR TITLE
Connect Orbit pages to API

### DIFF
--- a/apps/orbit/src/app/cosmo/page.tsx
+++ b/apps/orbit/src/app/cosmo/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useState } from "react";
 import { Button } from "../../components/ui/button";
-
-// TODO: Integrate real Cosmo SDK
+import { sendCosmoMessage } from "../../lib/api";
 export default function CosmoPage() {
   const [messages, setMessages] = useState<{from: string, text: string}[]>([]);
   const [input, setInput] = useState("");
@@ -12,11 +11,20 @@ export default function CosmoPage() {
     if (!input.trim()) return;
     setLoading(true);
     setMessages(msgs => [...msgs, { from: "user", text: input }]);
-    // TODO: Call Cosmo SDK
-    setTimeout(() => {
-      setMessages(msgs => [...msgs, { from: "cosmo", text: "This is a placeholder response from Cosmo." }]);
+    const token =
+      typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
+    try {
+      const res = await sendCosmoMessage(token, input);
+      if (res.success) {
+        setMessages(msgs => [...msgs, { from: "cosmo", text: res.message }]);
+      } else {
+        setMessages(msgs => [...msgs, { from: "cosmo", text: "Sorry, something went wrong." }]);
+      }
+    } catch {
+      setMessages(msgs => [...msgs, { from: "cosmo", text: "Sorry, something went wrong." }]);
+    } finally {
       setLoading(false);
-    }, 1000);
+    }
     setInput("");
   }
 

--- a/apps/orbit/src/app/knowledge/page.tsx
+++ b/apps/orbit/src/app/knowledge/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { useState } from "react";
 import { Button } from "../../components/ui/button";
+import { searchKnowledge } from "../../lib/api";
 
-// TODO: Replace with real KB search API
 export default function KnowledgePage() {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
   const [query, setQuery] = useState("");
 interface KnowledgeResult {
   id: string;
@@ -20,14 +22,18 @@ const [results, setResults] = useState<KnowledgeResult[]>([]);
     setLoading(true);
     setError(null);
     setResults([]);
-    // TODO: Call real KB search API
-    setTimeout(() => {
-      setResults([
-        { id: "1", title: "How to reset your password", summary: "Go to profile > security...", url: "#" },
-        { id: "2", title: "VPN setup guide", summary: "Download the VPN client...", url: "#" },
-      ]);
+    try {
+      const res = await searchKnowledge(token, query);
+      if (res.success) {
+        setResults(res.results || []);
+      } else {
+        setError(res.error || "Search failed");
+      }
+    } catch {
+      setError("Search failed");
+    } finally {
       setLoading(false);
-    }, 800);
+    }
   }
 
   return (

--- a/apps/orbit/src/app/profile/page.tsx
+++ b/apps/orbit/src/app/profile/page.tsx
@@ -1,25 +1,48 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "../../components/ui/button";
+import { getSession, updateProfile } from "../../lib/api";
 
-// TODO: Replace with real user profile API
 export default function ProfilePage() {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
+  const [userId, setUserId] = useState<string>("");
   const [profile, setProfile] = useState({
-    name: "Jane Doe",
-    email: "jane@example.com",
-    org: "Nova Corp",
+    name: "",
+    email: "",
+    org: "",
   });
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState(profile);
+
+  useEffect(() => {
+    if (!token) return;
+    getSession(token)
+      .then(res => {
+        if (res.success) {
+          setUserId(res.user.id);
+          const data = {
+            name: res.user.name || '',
+            email: res.user.email || '',
+            org: res.user.org || ''
+          };
+          setProfile(data);
+          setForm(data);
+        }
+      })
+      .catch(() => {});
+  }, [token]);
 
   function handleEdit() {
     setEditing(true);
     setForm(profile);
   }
   function handleSave() {
-    setProfile(form);
-    setEditing(false);
-    // TODO: Save to API
+    if (!token || !userId) return;
+    updateProfile(token, userId, form).then(() => {
+      setProfile(form);
+      setEditing(false);
+    });
   }
 
   return (

--- a/apps/orbit/src/app/status/page.tsx
+++ b/apps/orbit/src/app/status/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
+import { getServiceStatus } from "../../lib/api";
 
-
-// TODO: Replace with real status API
 interface StatusData {
   id: number;
   service: string;
@@ -12,17 +11,19 @@ interface StatusData {
 export default function StatusPage() {
   const [status, setStatus] = useState<StatusData[]>([]);
   const [loading, setLoading] = useState(false);
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") || "" : "";
 
   useEffect(() => {
     setLoading(true);
-    // TODO: Call real status API
-    setTimeout(() => {
-      setStatus([
-        { id: 1, service: "Email", state: "Operational", updated: "2025-07-28T10:00:00Z" },
-        { id: 2, service: "VPN", state: "Degraded", updated: "2025-07-28T09:00:00Z" },
-      ]);
-      setLoading(false);
-    }, 800);
+    getServiceStatus(token)
+      .then(res => {
+        if (res.success) {
+          setStatus(res.status || []);
+        }
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
   }, []);
 
   return (

--- a/apps/orbit/src/app/tickets/page.tsx
+++ b/apps/orbit/src/app/tickets/page.tsx
@@ -43,11 +43,10 @@ export default function TicketsPage() {
   const [total, setTotal] = useState(0);
   const limit = 10;
 
-  // TODO: Replace with real auth token from context/session
   const token =
-	typeof window !== "undefined"
-	  ? localStorage.getItem("token") || "demo-token"
-	  : "";
+        typeof window !== "undefined"
+          ? localStorage.getItem("token") || ""
+          : "";
 
   const router = useRouter();
 

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -116,6 +116,9 @@ export async function searchKnowledge(token: string, query: string) {
     headers: { Authorization: `Bearer ${token}` },
     credentials: 'include'
   });
+  if (!res.ok) {
+    throw new Error(`Failed to search knowledge: ${res.status} ${res.statusText}`);
+  }
   return res.json();
 }
 

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -102,6 +102,10 @@ export async function updateProfile(token: string, id: string, data: { name: str
     body: JSON.stringify(data),
     credentials: 'include'
   });
+  if (!res.ok) {
+    const errorDetails = await res.text();
+    throw new Error(`Failed to update profile: ${res.status} ${res.statusText} - ${errorDetails}`);
+  }
   return res.json();
 }
 

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -127,6 +127,9 @@ export async function getServiceStatus(token: string) {
     headers: { Authorization: `Bearer ${token}` },
     credentials: 'include'
   });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch service status: ${res.status} ${res.statusText}`);
+  }
   return res.json();
 }
 

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -80,3 +80,55 @@ export async function submitFeedback(token: string, data: FeedbackData) {
   });
   return res.json();
 }
+
+export async function getSession(token: string) {
+  const res = await fetch('/api/v1/helix/session', {
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: 'include'
+  });
+  return res.json();
+}
+
+export async function updateProfile(token: string, id: string, data: { name: string; email: string; org: string }) {
+  const res = await fetch(`/api/users/${id}`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(data),
+    credentials: 'include'
+  });
+  return res.json();
+}
+
+export async function searchKnowledge(token: string, query: string) {
+  const url = new URL('/api/v1/lore/search', window.location.origin);
+  url.searchParams.set('q', query);
+  const res = await fetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: 'include'
+  });
+  return res.json();
+}
+
+export async function getServiceStatus(token: string) {
+  const res = await fetch('/api/server/status', {
+    headers: { Authorization: `Bearer ${token}` },
+    credentials: 'include'
+  });
+  return res.json();
+}
+
+export async function sendCosmoMessage(token: string, message: string) {
+  const res = await fetch('/api/v1/synth/chat', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify({ message }),
+    credentials: 'include'
+  });
+  return res.json();
+}

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -140,5 +140,9 @@ export async function sendCosmoMessage(token: string, message: string) {
     body: JSON.stringify({ message }),
     credentials: 'include'
   });
+  if (!res.ok) {
+    const errorDetails = await res.text(); // Attempt to extract error details
+    throw new Error(`Failed to send message: ${res.status} ${res.statusText} - ${errorDetails}`);
+  }
   return res.json();
 }

--- a/apps/orbit/src/lib/api.ts
+++ b/apps/orbit/src/lib/api.ts
@@ -86,6 +86,9 @@ export async function getSession(token: string) {
     headers: { Authorization: `Bearer ${token}` },
     credentials: 'include'
   });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch session: ${res.status} ${res.statusText}`);
+  }
   return res.json();
 }
 


### PR DESCRIPTION
## Summary
- hook Orbit profile page to /api endpoints
- call KB search and service status endpoints from Orbit
- use backend chat endpoint for Cosmo
- clean up auth token usage in tickets
- expose new API helpers

## Testing
- `npm test` *(fails: Cannot find module 'cors' from 'index.js')*

------
https://chatgpt.com/codex/tasks/task_e_6889373a377083339cff8dbbd692458e