### PR TITLE
Fix missing async keyword

### DIFF
--- a/apps/api/routes/helix.js
+++ b/apps/api/routes/helix.js
@@ -1023,7 +1023,7 @@ router.get('/sso/saml/login', (req, res, next) => {
  *       500:
  *         description: SAML processing error
  */
-router.post('/sso/saml/callback', (req, res, next) => {
+router.post('/sso/saml/callback', async (req, res, next) => {
   try {
     const passport = configureSAML();
     passport.authenticate('saml', { session: false }, async (err, user, info) => {


### PR DESCRIPTION
## Summary
- mark SAML callback route async

## Testing
- `npm test` *(fails: Cannot find module 'cors' from 'index.js')*


------
https://chatgpt.com/codex/tasks/task_e_68895657d5e8833385cbe94285c2217e