### PR TITLE
Add branding configuration support

### DIFF
--- a/apps/api/config/app-settings.js
+++ b/apps/api/config/app-settings.js
@@ -19,6 +19,8 @@ const DEFAULT_CONFIG = {
     name: 'Nova Universe',
     logoUrl: '/logo.png',
     faviconUrl: '/vite.svg',
+    primaryColor: '#1D4ED8',
+    secondaryColor: '#9333EA',
     welcomeMessage: 'Welcome to the Help Desk',
     helpMessage: 'Need to report an issue?'
   },
@@ -231,6 +233,22 @@ class ConfigurationManager {
       config.organization = config.organization || {};
       config.organization.faviconUrl = process.env.FAVICON_URL;
     }
+    if (process.env.PRIMARY_COLOR) {
+      config.organization = config.organization || {};
+      config.organization.primaryColor = process.env.PRIMARY_COLOR;
+    }
+    if (process.env.SECONDARY_COLOR) {
+      config.organization = config.organization || {};
+      config.organization.secondaryColor = process.env.SECONDARY_COLOR;
+    }
+    if (process.env.WELCOME_MESSAGE) {
+      config.organization = config.organization || {};
+      config.organization.welcomeMessage = process.env.WELCOME_MESSAGE;
+    }
+    if (process.env.HELP_MESSAGE) {
+      config.organization = config.organization || {};
+      config.organization.helpMessage = process.env.HELP_MESSAGE;
+    }
 
     // Security settings
     if (process.env.MIN_PIN_LENGTH) {
@@ -307,6 +325,9 @@ class ConfigurationManager {
       }
       if (key.includes('Url')) {
         return typeof value === 'string' && (value.startsWith('/') || value.startsWith('http'));
+      }
+      if (key === 'organization.primaryColor' || key === 'organization.secondaryColor') {
+        return typeof value === 'string' && /^#([0-9A-Fa-f]{3}){1,2}$/.test(value);
       }
 
       // Rate limiting validation

--- a/apps/api/migrations/seeds/001_default_data.sql
+++ b/apps/api/migrations/seeds/001_default_data.sql
@@ -49,6 +49,8 @@ INSERT INTO config (key, value, value_type, description, is_public, category) VA
 ('organization_name', COALESCE(NULLIF(current_setting('app.organization_name', true), ''), 'Your Organization'), 'string', 'Organization name displayed throughout the application', true, 'general'),
 ('logo_url', COALESCE(NULLIF(current_setting('app.logo_url', true), ''), '/logo.png'), 'string', 'URL to organization logo', true, 'branding'),
 ('favicon_url', COALESCE(NULLIF(current_setting('app.favicon_url', true), ''), '/vite.svg'), 'string', 'URL to site favicon', true, 'branding'),
+('primary_color', COALESCE(NULLIF(current_setting('app.primary_color', true), ''), '#1D4ED8'), 'string', 'Primary theme color', true, 'branding'),
+('secondary_color', COALESCE(NULLIF(current_setting('app.secondary_color', true), ''), '#9333EA'), 'string', 'Secondary theme color', true, 'branding'),
 ('welcome_message', 'Welcome to the Help Desk', 'string', 'Welcome message displayed on kiosks', true, 'kiosk'),
 ('help_message', 'Need to report an issue?', 'string', 'Help message displayed on kiosks', true, 'kiosk'),
 ('status_open_msg', 'Open', 'string', 'Message displayed when status is open', true, 'kiosk'),

--- a/apps/beacon/nova-beacon/Nova Beacon/Nova Beacon/Services/EnhancedConfigService.swift
+++ b/apps/beacon/nova-beacon/Nova Beacon/Nova Beacon/Services/EnhancedConfigService.swift
@@ -191,6 +191,10 @@ class EnhancedConfigService: ObservableObject {
                 config.welcomeMessage = value as? String ?? config.welcomeMessage
             case "helpMessage":
                 config.helpMessage = value as? String ?? config.helpMessage
+            case "primaryColor":
+                config.theme.primaryColor = value as? String ?? config.theme.primaryColor
+            case "secondaryColor":
+                config.theme.secondaryColor = value as? String ?? config.theme.secondaryColor
             default:
                 break
             }

--- a/apps/beacon/nova-beacon/Nova Beacon/Nova Beacon/Views/EnhancedAdminLoginView.swift
+++ b/apps/beacon/nova-beacon/Nova Beacon/Nova Beacon/Views/EnhancedAdminLoginView.swift
@@ -422,6 +422,8 @@ struct BrandingManagementView: View {
     @State private var logoUrl: String = ""
     @State private var welcomeMessage: String = ""
     @State private var helpMessage: String = ""
+    @State private var primaryColor: String = "#1D4ED8"
+    @State private var secondaryColor: String = "#9333EA"
     
     var body: some View {
         Form {
@@ -444,8 +446,15 @@ struct BrandingManagementView: View {
             Section("Messages") {
                 TextField("Welcome Message", text: $welcomeMessage)
                     .textFieldStyle(.roundedBorder)
-                
+
                 TextField("Help Message", text: $helpMessage)
+                    .textFieldStyle(.roundedBorder)
+            }
+
+            Section("Colors") {
+                TextField("Primary Color", text: $primaryColor)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Secondary Color", text: $secondaryColor)
                     .textFieldStyle(.roundedBorder)
             }
             
@@ -455,7 +464,9 @@ struct BrandingManagementView: View {
                         let updates = [
                             "logoUrl": logoUrl,
                             "welcomeMessage": welcomeMessage,
-                            "helpMessage": helpMessage
+                            "helpMessage": helpMessage,
+                            "primaryColor": primaryColor,
+                            "secondaryColor": secondaryColor
                         ]
                         await configService.updateLocalConfig(updates, source: "kiosk")
                     }
@@ -467,6 +478,8 @@ struct BrandingManagementView: View {
             logoUrl = configService.localConfig?.logoUrl ?? ""
             welcomeMessage = configService.localConfig?.welcomeMessage ?? ""
             helpMessage = configService.localConfig?.helpMessage ?? ""
+            primaryColor = configService.localConfig?.theme.primaryColor ?? "#1D4ED8"
+            secondaryColor = configService.localConfig?.theme.secondaryColor ?? "#9333EA"
         }
     }
 }

--- a/apps/core/nova-core/src/lib/api.ts
+++ b/apps/core/nova-core/src/lib/api.ts
@@ -414,7 +414,7 @@ class ApiClient {
     return response.data;
   }
 
-  async getOrganizationBranding(): Promise<any> {
+  async getOrganizationBranding(): Promise<OrganizationBranding> {
     if (this.useMockMode) {
       return this.mockRequest({
         logoUrl: '/logo.png',

--- a/apps/core/nova-core/src/lib/api.ts
+++ b/apps/core/nova-core/src/lib/api.ts
@@ -414,6 +414,21 @@ class ApiClient {
     return response.data;
   }
 
+  async getOrganizationBranding(): Promise<any> {
+    if (this.useMockMode) {
+      return this.mockRequest({
+        logoUrl: '/logo.png',
+        welcomeMessage: 'Welcome',
+        helpMessage: 'Need help?',
+        primaryColor: '#1D4ED8',
+        secondaryColor: '#9333EA'
+      });
+    }
+
+    const response = await this.client.get('/api/v1/organizations/config');
+    return response.data;
+  }
+
   // Notifications
   async getNotifications(): Promise<Notification[]> {
     if (this.useMockMode) {

--- a/apps/core/nova-core/src/lib/mockData.ts
+++ b/apps/core/nova-core/src/lib/mockData.ts
@@ -138,6 +138,8 @@ export const mockLogs: Log[] = [
 export const mockConfig: Config = {
   logoUrl: 'https://via.placeholder.com/200x60/3B82F6/FFFFFF?text=CueIT',
   faviconUrl: 'https://via.placeholder.com/32x32/3B82F6/FFFFFF?text=C',
+  primaryColor: '#1D4ED8',
+  secondaryColor: '#9333EA',
   welcomeMessage: 'Welcome to CueIT Support',
   helpMessage: 'Please describe your issue and we will help you',
   statusOpenMsg: 'IT Support is available',

--- a/apps/core/nova-core/src/pages/SettingsPage.tsx
+++ b/apps/core/nova-core/src/pages/SettingsPage.tsx
@@ -509,7 +509,10 @@ export const SettingsPage: React.FC = () => {
                               id="primary-color"
                               type="color"
                               className="w-full h-10 border border-gray-300 rounded-md"
-                              defaultValue="#3B82F6"
+                              value={config?.primaryColor || '#3B82F6'}
+                              onChange={(e) =>
+                                setConfig(prev => prev ? { ...prev, primaryColor: e.target.value } : null)
+                              }
                               title="Primary theme color"
                             />
                           </div>
@@ -521,7 +524,10 @@ export const SettingsPage: React.FC = () => {
                               id="secondary-color"
                               type="color"
                               className="w-full h-10 border border-gray-300 rounded-md"
-                              defaultValue="#6B7280"
+                              value={config?.secondaryColor || '#6B7280'}
+                              onChange={(e) =>
+                                setConfig(prev => prev ? { ...prev, secondaryColor: e.target.value } : null)
+                              }
                               title="Secondary theme color"
                             />
                           </div>

--- a/apps/core/nova-core/src/pages/auth/LoginPage.tsx
+++ b/apps/core/nova-core/src/pages/auth/LoginPage.tsx
@@ -17,7 +17,7 @@ export const LoginPage: React.FC = () => {
   const [ssoAvailable, setSsoAvailable] = useState(false);
   const [ssoLoginUrl, setSsoLoginUrl] = useState<string | null>(null);
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
-  const [branding, setBranding] = useState<any>({});
+  const [branding, setBranding] = useState<Branding>({});
   const navigate = useNavigate();
   const { login } = useAuthStore();
   const { addToast } = useToastStore();

--- a/apps/core/nova-core/src/pages/auth/LoginPage.tsx
+++ b/apps/core/nova-core/src/pages/auth/LoginPage.tsx
@@ -76,7 +76,12 @@ export const LoginPage: React.FC = () => {
     };
 
     checkSSOAndToken();
-    api.getOrganizationBranding().then(setBranding).catch(() => {});
+    api.getOrganizationBranding()
+      .then(setBranding)
+      .catch((error) => {
+        console.error('Failed to fetch organization branding:', error);
+        setBranding({ logo: null, themeColor: '#000000' }); // Fallback branding
+      });
   }, [login, navigate, addToast]);
 
   const handlePasskeyLogin = async () => {

--- a/apps/core/nova-core/src/pages/auth/LoginPage.tsx
+++ b/apps/core/nova-core/src/pages/auth/LoginPage.tsx
@@ -17,6 +17,7 @@ export const LoginPage: React.FC = () => {
   const [ssoAvailable, setSsoAvailable] = useState(false);
   const [ssoLoginUrl, setSsoLoginUrl] = useState<string | null>(null);
   const [passkeyAvailable, setPasskeyAvailable] = useState(false);
+  const [branding, setBranding] = useState<any>({});
   const navigate = useNavigate();
   const { login } = useAuthStore();
   const { addToast } = useToastStore();
@@ -75,6 +76,7 @@ export const LoginPage: React.FC = () => {
     };
 
     checkSSOAndToken();
+    api.getOrganizationBranding().then(setBranding).catch(() => {});
   }, [login, navigate, addToast]);
 
   const handlePasskeyLogin = async () => {
@@ -240,18 +242,18 @@ export const LoginPage: React.FC = () => {
           <div className="mx-auto h-24 w-48 flex items-center justify-center mb-8">
             <img
               className="h-20 w-auto max-w-full object-contain"
-              src="/logo.png"
-              alt="Nova Universe"
+              src={branding.logoUrl || '/logo.png'}
+              alt="Organization logo"
               onError={(e) => {
                 e.currentTarget.src = '/vite.svg';
               }}
             />
           </div>
           <h2 className="mt-6 text-center text-3xl font-bold text-gray-900 dark:text-gray-100">
-            Sign in to Nova Universe Portal
+            {branding.welcomeMessage || 'Sign in to Nova Universe Portal'}
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
-            Manage your kiosks, users, and support tickets
+            {branding.helpMessage || 'Manage your kiosks, users, and support tickets'}
           </p>
         </div>
 

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -102,6 +102,8 @@ export interface Config {
   logoUrl: string;
   faviconUrl: string;
   kioskLogoUrl?: string;
+  primaryColor?: string;
+  secondaryColor?: string;
   welcomeMessage: string;
   helpMessage: string;
   statusOpenMsg: string;
@@ -299,6 +301,8 @@ export interface KioskConfiguration {
     override: ConfigOverride;
     logoUrl?: string;
     backgroundUrl?: string;
+    primaryColor?: string;
+    secondaryColor?: string;
     welcomeMessage?: string;
     helpMessage?: string;
   };
@@ -324,6 +328,8 @@ export interface GlobalConfiguration {
   defaultBranding: {
     logoUrl: string;
     backgroundUrl?: string;
+    primaryColor: string;
+    secondaryColor: string;
     welcomeMessage: string;
     helpMessage: string;
   };

--- a/apps/orbit/src/app/layout.tsx
+++ b/apps/orbit/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { KioskRedirect } from "../components/KioskRedirect";
+import { defaultBranding } from "../lib/branding";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,6 +28,10 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        style={{
+          '--color-primary': defaultBranding.primaryColor,
+          '--color-secondary': defaultBranding.secondaryColor,
+        } as React.CSSProperties}
       >
         <KioskRedirect />
         {children}

--- a/apps/orbit/src/app/page.tsx
+++ b/apps/orbit/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Image from "next/image";
 import Link from "next/link";
+import { defaultBranding } from "../lib/branding";
 
 export default function HomePage() {
   return (
@@ -14,10 +15,10 @@ export default function HomePage() {
           height={38}
           priority
         />
-        <h1 className="text-3xl font-bold mb-2">Welcome to Nova Orbit</h1>
-        <p className="mb-6 text-muted-foreground">
-          Your unified portal for IT support, knowledge, and service status.
-        </p>
+        <h1 className="text-3xl font-bold mb-2">
+          {defaultBranding.welcomeMessage || 'Welcome to Nova Orbit'}
+        </h1>
+        <p className="mb-6 text-muted-foreground">{defaultBranding.helpText}</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
           <Link
             href="/tickets"

--- a/apps/orbit/src/lib/branding.ts
+++ b/apps/orbit/src/lib/branding.ts
@@ -16,6 +16,6 @@ export const defaultBranding: BrandingConfig = {
   primaryColor: '#3b82f6',
   secondaryColor: '#6366f1',
   welcomeMessage: 'Welcome to Nova Orbit!',
-  helpText: 'Welcome to Nova Orbit!',
+  helpText: 'Need help? Explore our documentation or contact support.',
   fallbackToNova: true,
 };

--- a/apps/orbit/src/lib/branding.ts
+++ b/apps/orbit/src/lib/branding.ts
@@ -4,6 +4,7 @@ export type BrandingConfig = {
   logoUrl: string;
   primaryColor: string;
   secondaryColor: string;
+  welcomeMessage?: string;
   helpText: string;
   fallbackToNova: boolean;
 };
@@ -14,6 +15,7 @@ export const defaultBranding: BrandingConfig = {
   logoUrl: '/nova-logo-light.png',
   primaryColor: '#3b82f6',
   secondaryColor: '#6366f1',
+  welcomeMessage: 'Welcome to Nova Orbit!',
   helpText: 'Welcome to Nova Orbit!',
   fallbackToNova: true,
 };


### PR DESCRIPTION
## Summary
- extend default config with branding fields and validation
- allow branding color updates through SettingsPage
- pull organization branding on login screen
- expose branding data via API client
- adjust Swift beacon views to edit colors
- apply tenant colors in Orbit layout

## Testing
- `npm test` *(fails: Cannot find module '/workspace/nova-universe/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_688989192f888333a96e2588c2f4a57a