### PR TITLE
Update setup paths for app directories

### DIFF
--- a/tools/scripts/scripts/init-env.sh
+++ b/tools/scripts/scripts/init-env.sh
@@ -1,15 +1,20 @@
 #!/bin/bash
 set -e
 
-apps=(nova-api nova-core nova-comms)
+apps=("apps/api" "apps/core/nova-core" "apps/comms/nova-comms")
 
 for app in "${apps[@]}"; do
   example="$app/.env.example"
   env="$app/.env"
+  if [ -f "$env" ]; then
+    continue
+  fi
+
   if [ -f "$example" ]; then
-    if [ ! -f "$env" ]; then
-      cp "$example" "$env"
-      echo "Created $env. Remember to edit the values." >&2
-    fi
+    cp "$example" "$env"
+    echo "Created $env. Remember to edit the values." >&2
+  elif [ -f ".env.example" ]; then
+    cp .env.example "$env"
+    echo "Copied root .env.example to $env. Edit the values." >&2
   fi
 done

--- a/tools/scripts/scripts/setup.sh
+++ b/tools/scripts/scripts/setup.sh
@@ -17,23 +17,27 @@ if ! command -v mailpit >/dev/null 2>&1; then
 fi
 
 # Install Node dependencies for backend, admin, and comms service
-pushd nova-api >/dev/null
+nova_api_dir="apps/api"
+nova_core_dir="apps/core/nova-core"
+nova_comms_dir="apps/comms/nova-comms"
+
+pushd "$nova_api_dir" >/dev/null
 npm ci
 popd >/dev/null
 
-pushd nova-core >/dev/null
+pushd "$nova_core_dir" >/dev/null
 npm ci
 popd >/dev/null
 
-if [ -d nova-comms ]; then
-  pushd nova-comms >/dev/null
+if [ -d "$nova_comms_dir" ]; then
+  pushd "$nova_comms_dir" >/dev/null
   npm ci
   popd >/dev/null
 fi
 
 # Automatically create .env files if they do not exist
 missing_env=false
-for dir in nova-api nova-core nova-comms; do
+for dir in "$nova_api_dir" "$nova_core_dir" "$nova_comms_dir"; do
   [ -f "$dir/.env" ] || missing_env=true
 done
 if [ "$missing_env" = true ]; then
@@ -48,4 +52,4 @@ echo "   Email: admin@example.com"
 echo "   Password: admin"
 echo ""
 echo "You can create/update admin users manually with:"
-echo "   cd nova-api && node create-admin.js [email] [password] [name]"
+echo "   cd $nova_api_dir && node create-admin.js [email] [password] [name]"


### PR DESCRIPTION
## Summary
- update `setup.sh` paths for apps under `apps/`
- update `init-env.sh` to create `.env` files in new locations

## Testing
- `pnpm install`
- `pnpm test` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_688a2edc25048333bc52364a6fb478f6