### PR TITLE
Document pnpm install workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,8 @@ Open http://localhost:5173 to access the admin interface.
 
 ## Setup
 
-Run `./installers/setup.sh` to install Node.js and all project dependencies in one step.
+Run `./installers/setup.sh` to install Node.js.
+Then run `pnpm install` from the repository root to install dependencies across all workspaces.
 Copy `.env.local.example` to `.env.local` and adjust any values for your machine.
 Next run `./scripts/init-env.sh` to create the `.env` files for each app (edit them before launching).
 You can also follow the manual instructions below.
@@ -134,7 +135,7 @@ See [Local vs Production Setup](docs/environments.md) for details on configuring
 
 ### Platform API
 1. Navigate to `nova-api`.
-2. Run `npm install` to install dependencies.
+2. Dependencies should already be installed from the repository root with `pnpm install`.
 3. Edit the `.env` file with your SMTP configuration and `HELPDESK_EMAIL`.
    To send tickets directly to HelpScout instead, provide
    `HELPSCOUT_API_KEY` and `HELPSCOUT_MAILBOX_ID` (optionally set
@@ -158,7 +159,7 @@ query {
 
 ### Core Admin UI
 1. Navigate to `nova-core`.
-2. Run `npm install` to install dependencies.
+2. Dependencies should already be installed from the repository root with `pnpm install`.
 3. Edit the `.env` file and set `VITE_API_URL`. You can also set `VITE_LOGO_URL`.
 4. Start the development server with `npm run dev` and open `http://localhost:5173`.
 
@@ -174,7 +175,7 @@ Configuration values are stored in the same database and can be edited from the 
 
 ### Comms (Slack Service)
 1. Create a Slack app following [Slack's app setup guide](https://api.slack.com/apps) and add a `/new-ticket` slash command (see [Slash commands documentation](https://api.slack.com/interactivity/slash-commands)). Set its request URL to this service.
-2. Navigate to `nova-comms` and run `npm install`.
+2. Navigate to `nova-comms` (dependencies were installed from the repository root with `pnpm install`).
 3. Edit the `.env` file and set:
    - `SLACK_SIGNING_SECRET`
    - `SLACK_BOT_TOKEN`
@@ -248,16 +249,14 @@ Nova Universe includes automated test suites for the backend API and the admin U
 ### nova-api
 
 1. `cd nova-api`
-2. `npm install`
-3. `npm test`
+2. `pnpm test`
 
 The API tests are written with Mocha and exercise the main Express endpoints.
 
 ### nova-core
 
 1. `cd nova-core`
-2. `npm install`
-3. `npm test`
+2. `pnpm test`
 
 This suite uses Jest and React Testing Library to validate the UI.
 

--- a/README.md
+++ b/README.md
@@ -248,15 +248,15 @@ Nova Universe includes automated test suites for the backend API and the admin U
 
 ### nova-api
 
-1. `cd nova-api`
-2. `pnpm test`
+Run from the repository root:
+1. `pnpm --filter nova-universe-api test`
 
 The API tests are written with Mocha and exercise the main Express endpoints.
 
 ### nova-core
 
-1. `cd nova-core`
-2. `pnpm test`
+Run from the repository root:
+1. `pnpm --filter nova-core-admin test`
 
 This suite uses Jest and React Testing Library to validate the UI.
 

--- a/docs/DATABASE_UPGRADE.md
+++ b/docs/DATABASE_UPGRADE.md
@@ -86,7 +86,7 @@ This will start:
 
 Install the required database drivers:
 ```bash
-npm install
+pnpm install
 ```
 
 ### 5. Run Migrations

--- a/docs/DATABASE_UPGRADE.md
+++ b/docs/DATABASE_UPGRADE.md
@@ -444,13 +444,13 @@ db.system.profile.find().limit(5).sort({ ts: -1 });
 
 ```bash
 # Full test suite
-npm test
+pnpm test
 
 # Database-specific tests
-npm test test/database.test.js
+pnpm test test/database.test.js
 
 # Integration tests
-npm test test/integration.test.js
+pnpm test test/integration.test.js
 ```
 
 ### Test Configuration
@@ -558,7 +558,7 @@ When reporting issues, include:
 ### Contributing
 
 Contributions are welcome! Please:
-1. Run tests: `npm test`
+1. Run tests: `pnpm test`
 2. Follow code style guidelines
 3. Add tests for new features
 4. Update documentation

--- a/docs/DATABASE_UPGRADE_COMPLETE.md
+++ b/docs/DATABASE_UPGRADE_COMPLETE.md
@@ -250,13 +250,13 @@ const health = await db.healthCheck();
 ### Running Tests
 ```bash
 # Run all database tests
-npm test test/database.test.js
+pnpm test test/database.test.js
 
 # Verify setup
 node test-db-setup.js
 
 # Integration testing
-npm test
+pnpm test
 ```
 
 ## 🚀 Production Deployment

--- a/docs/DATABASE_UPGRADE_COMPLETE.md
+++ b/docs/DATABASE_UPGRADE_COMPLETE.md
@@ -98,8 +98,8 @@ node migrate-database.js --source ./nova-api/log.sqlite --target both
 
 ### 4. Start Application
 ```bash
-npm install
-npm start
+pnpm install
+pnpm start
 ```
 
 ## 🔧 Technical Implementation

--- a/docs/README.md
+++ b/docs/README.md
@@ -211,10 +211,10 @@ See [SECURITY_FIXES.md](SECURITY_FIXES.md) for detailed security implementation.
 
 ### Testing
 ```bash
-# Run tests for each component
-cd cueit-api && npm test
-cd cueit-admin && npm test
-cd cueit-slack && npm test
+# Run tests for each component from the repository root
+pnpm --filter cueit-api test
+pnpm --filter cueit-admin test
+pnpm --filter cueit-slack test
 ```
 
 ### Development Scripts

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,8 +16,8 @@
 ## Testing
 - Run `./setup.sh` to install Node.js, SQLite and all project dependencies if needed
 - Each package has its own test suite
-- Navigate to a package and run `npm test`
-- Run `npm run lint` before committing changes
+- Navigate to a package and run `pnpm test` or run `pnpm --filter <workspace> test` from the repository root
+- Run `pnpm run lint` before committing changes
 - Installer and upgrade scripts live in `installers/` and must include basic tests
 
 ## Linting

--- a/docs/enhanced-database-architecture.md
+++ b/docs/enhanced-database-architecture.md
@@ -196,7 +196,7 @@ docker-compose up elasticsearch kibana  # Elasticsearch + Kibana
 ### 🚀 Setup and Initialization
 ```bash
 # 1. Install dependencies
-npm install
+pnpm install
 
 # 2. Generate Prisma client
 npx prisma generate

--- a/docs/enhanced-database-architecture.md
+++ b/docs/enhanced-database-architecture.md
@@ -208,7 +208,7 @@ docker-compose up -d postgres mongodb elasticsearch
 npx prisma db push
 
 # 5. Test setup
-npm test test/database-setup.test.js
+pnpm test test/database-setup.test.js
 ```
 
 ### 🔧 Database Management

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -5,6 +5,7 @@ Get CueIT running in 5 minutes.
 ## Prerequisites
 - [Node.js](https://nodejs.org/) 18+
 - npm
+- [pnpm](https://pnpm.io/installation) (install with `npm install -g pnpm`)
 - SQLite3
 
 ## Quick Setup

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -13,7 +13,7 @@ Get CueIT running in 5 minutes.
    ```bash
    git clone https://github.com/your-org/CueIT.git
    cd CueIT
-   ./installers/setup.sh
+   pnpm install
    ```
 
 2. **Configure**
@@ -67,7 +67,7 @@ HELPDESK_EMAIL=helpdesk@company.com
 **Services won't start?**
 - Check that ports 3000 and 5173 are available
 - Ensure Node.js 18+ is installed
-- Run `npm install` in each service directory
+- Run `pnpm install` from the repository root to install workspace dependencies
 
 **Can't connect to admin interface?**
 - Verify the API is running at http://localhost:3000/api/health (see also /api/version for version info)

--- a/tools/scripts/scripts/setup.sh
+++ b/tools/scripts/scripts/setup.sh
@@ -17,24 +17,13 @@ if ! command -v mailpit >/dev/null 2>&1; then
   echo "Mailpit not found – install from https://github.com/axllent/mailpit if needed."
 fi
 
-# Install Node dependencies for backend, admin, and comms service
+# Workspace directories
 nova_api_dir="apps/api"
 nova_core_dir="apps/core/nova-core"
 nova_comms_dir="apps/comms/nova-comms"
 
-pushd "$nova_api_dir" >/dev/null
-npm ci
-popd >/dev/null
-
-pushd "$nova_core_dir" >/dev/null
-npm ci
-popd >/dev/null
-
-if [ -d "$nova_comms_dir" ]; then
-  pushd "$nova_comms_dir" >/dev/null
-  npm ci
-  popd >/dev/null
-fi
+# Install dependencies for all workspaces
+pnpm install
 
 # Automatically create .env files if they do not exist
 missing_env=false


### PR DESCRIPTION
## Summary
- document running `pnpm install` before development
- update quickstart and docs with pnpm commands
- simplify setup script to run `pnpm install`

## Testing
- `pnpm test` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_688a35f8e4e0833389b9fdf63926ec23