### PR TITLE
Fix Jest config path

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -11,10 +11,13 @@ const config: JestConfigWithTsJest = {
     '^.+\\.js$': 'babel-jest',
     '^.+\\.mjs$': 'babel-jest'
   },
-  extensionsToTreatAsEsm: ['.ts', '.mjs'],
+  extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
+  transformIgnorePatterns: [
+    '/node_modules/(?!(\\.prisma/client)/)'
+  ]
 };
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config apps/api/jest.config.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config apps/api/jest.config.ts",
     "type-check": "tsc --noEmit",
     "lint": "eslint . --config ./tools/config/eslint.config.js"
   },
@@ -25,6 +25,7 @@
     "nodemailer": "^7.0.5",
     "prisma": "^6.12.0",
     "supertest": "^7.1.4",
+    "ts-node": "^10.9.2",
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "vite": "^7.0.6",


### PR DESCRIPTION
## Summary
- point root test script to apps/api/jest.config.ts
- configure ts-jest in apps/api/jest.config.ts for ESM and allow Prisma client

## Testing
- `npm test` *(fails: Must use import to load ES Module)*

------
https://chatgpt.com/codex/tasks/task_e_688ab08837508333bfd35c28154d4330