### PR TITLE
Add environment validation

### DIFF
--- a/apps/api/config/environment.js
+++ b/apps/api/config/environment.js
@@ -1,10 +1,22 @@
 import dotenv from 'dotenv';
+import { validateDatabaseConfig } from './database.js';
 dotenv.config();
 
 const required = [
   'SESSION_SECRET',
-  'JWT_SECRET'
+  'JWT_SECRET',
+  'KIOSK_TOKEN',
+  'SCIM_TOKEN'
 ];
+
+// Database configuration
+if (!process.env.DATABASE_URL) {
+  required.push('POSTGRES_HOST', 'POSTGRES_USER', 'POSTGRES_PASSWORD', 'POSTGRES_DB');
+}
+
+if (process.env.MONGO_ENABLED === 'true') {
+  required.push('MONGO_HOST', 'MONGO_DB');
+}
 
 // Only require SMTP in production
 if (process.env.NODE_ENV === 'production') {
@@ -47,6 +59,9 @@ export const validateEnvironment = () => {
     console.warn('⚠️  Environment warnings:');
     warnings.forEach(warning => console.warn(`   - ${warning}`));
   }
+
+  // Validate database configuration separately
+  validateDatabaseConfig();
   
   return {
     environment: env,

--- a/apps/comms/nova-comms/environment.js
+++ b/apps/comms/nova-comms/environment.js
@@ -1,0 +1,17 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export function validateEnv() {
+  const required = ['SLACK_SIGNING_SECRET', 'SLACK_BOT_TOKEN', 'API_URL', 'JWT_SECRET'];
+  const missing = required.filter((v) => !process.env[v]);
+  if (missing.length) {
+    throw new Error(`Missing required environment variables: ${missing.join(', ')}`);
+  }
+
+  return {
+    port: parseInt(process.env.SLACK_PORT) || 3001,
+    jwtExpiresIn: process.env.JWT_EXPIRES_IN || '1h',
+    adminUrl: process.env.VITE_ADMIN_URL
+  };
+}

--- a/apps/comms/nova-comms/index.js
+++ b/apps/comms/nova-comms/index.js
@@ -15,29 +15,15 @@
  * - VITE_ADMIN_URL: Admin panel URL for ticket links
  */
 
-import dotenv from 'dotenv';
 import { App } from '@slack/bolt';
 import axios from 'axios';
 import jwt from 'jsonwebtoken';
+import { validateEnv } from './environment.js';
+import dotenv from 'dotenv';
 
 dotenv.config();
 
-const PORT = process.env.SLACK_PORT || 3001;
-
-// Validate required environment variables
-const requiredEnvVars = [
-  'SLACK_SIGNING_SECRET',
-  'SLACK_BOT_TOKEN', 
-  'API_URL',
-  'JWT_SECRET'
-];
-
-// for (const envVar of requiredEnvVars) {
-//   if (!process.env[envVar]) {
-//     console.error(`Missing required environment variable: ${envVar}`);
-//     process.exit(1);
-//   }
-// }
+const { port: PORT, jwtExpiresIn } = validateEnv();
 
 const app = new App({
   signingSecret: process.env.SLACK_SIGNING_SECRET,
@@ -126,7 +112,7 @@ app.command('/new-ticket', async ({ ack, body, client }) => {
     const token = jwt.sign(
       { type: 'slack' },
       process.env.JWT_SECRET,
-      { expiresIn: process.env.JWT_EXPIRES_IN || '1h' }
+      { expiresIn: jwtExpiresIn }
     );
     const res = await axios.get(`${process.env.API_URL}/api/config`, {
       headers: { Authorization: `Bearer ${token}` },
@@ -172,7 +158,7 @@ app.view('ticket_submit', async ({ ack, body, view, client }) => {
     const token = jwt.sign(
       { type: 'slack' },
       process.env.JWT_SECRET,
-      { expiresIn: process.env.JWT_EXPIRES_IN || '1h' }
+      { expiresIn: jwtExpiresIn }
     );
     const res = await axios.post(
       `${process.env.API_URL}/submit-ticket`,

--- a/apps/core/nova-core/src/lib/api.ts
+++ b/apps/core/nova-core/src/lib/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance } from 'axios';
+import { getEnv } from './env';
 import type {
   User,
   Role,
@@ -34,8 +35,8 @@ import {
   shouldSimulateError,
 } from './mockData';
 
-// Check if we should use mock mode (when API is not available or VITE_USE_MOCK_API is true)
-const USE_MOCK_API = import.meta.env.VITE_USE_MOCK_API === 'true';
+// Load environment settings
+const { apiUrl, useMockApi: USE_MOCK_API } = getEnv();
 
 class ApiClient {
   private client: AxiosInstance;
@@ -88,11 +89,8 @@ class ApiClient {
   // Get the current server URL from localStorage or environment
   private getServerUrl(): string {
     const storedUrl = localStorage.getItem('api_server_url');
-    const envUrl = import.meta.env.VITE_API_URL;
-    const defaultUrl = 'http://localhost:3000';
-    
-    // Use stored URL if available, otherwise environment URL, otherwise default
-    return storedUrl || envUrl || defaultUrl;
+    // Use stored URL if available, otherwise value from environment helper
+    return storedUrl || apiUrl;
   }
 
   // Mock method helper

--- a/apps/core/nova-core/src/lib/env.ts
+++ b/apps/core/nova-core/src/lib/env.ts
@@ -1,0 +1,10 @@
+export function getEnv() {
+  const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+  if (!import.meta.env.VITE_API_URL) {
+    console.warn('VITE_API_URL not set - using default http://localhost:3000');
+  }
+  return {
+    apiUrl,
+    useMockApi: import.meta.env.VITE_USE_MOCK_API === 'true'
+  };
+}


### PR DESCRIPTION
## Summary
- enforce checks for env vars in API and validate database
- add env validation module for slack service
- ensure core admin uses helper to read Vite env values

## Testing
- `pnpm test --silent` *(fails: Cannot find module '.prisma/client/default')*

------
https://chatgpt.com/codex/tasks/task_e_688ab18024e48333afb2a96bdd28854a