### PR TITLE
Integrate Cosmo API utilities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -301,6 +301,8 @@ JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 ADMIN_EMAIL=admin@nova.local
 ADMIN_NAME=System Administrator
 ADMIN_PASSWORD=admin123
+# Cosmo service base URL
+COSMO_API_URL=http://localhost:5005
 
 # Pin settings
 MIN_PIN_LENGTH=4

--- a/apps/api/config/environment.js
+++ b/apps/api/config/environment.js
@@ -93,7 +93,8 @@ export const getConfig = () => {
     SLACK_WEBHOOK_URL: process.env.SLACK_WEBHOOK_URL,
     HELPSCOUT_API_KEY: process.env.HELPSCOUT_API_KEY,
     HELPSCOUT_MAILBOX_ID: process.env.HELPSCOUT_MAILBOX_ID,
-    HELPSCOUT_SMTP_FALLBACK: process.env.HELPSCOUT_SMTP_FALLBACK === 'true'
+    HELPSCOUT_SMTP_FALLBACK: process.env.HELPSCOUT_SMTP_FALLBACK === 'true',
+    COSMO_API_URL: process.env.COSMO_API_URL
   };
 };
 

--- a/apps/api/utils/cosmo.js
+++ b/apps/api/utils/cosmo.js
@@ -1,5 +1,39 @@
+import axios from 'axios';
 import { logger } from '../logger.js';
 
+const COSMO_URL = process.env.COSMO_API_URL || 'http://localhost:5005';
+
+/**
+ * Send a chat message to the Cosmo service.
+ * @param {object} params
+ * @param {string} params.userId - ID of the user sending the message
+ * @param {string} params.message - Message text
+ * @param {string} [params.conversationId] - Existing conversation ID
+ * @returns {Promise<object>} Response from Cosmo
+ */
+export async function sendCosmoMessage({ userId, message, conversationId }) {
+  try {
+    const { data } = await axios.post(
+      `${COSMO_URL}/v1/chat`,
+      { userId, message, conversationId }
+    );
+    return data;
+  } catch (err) {
+    logger.error('Error communicating with Cosmo', err);
+    throw err;
+  }
+}
+
+/**
+ * Notify Cosmo that a VIP ticket requires escalation.
+ * @param {string} ticketId
+ * @param {string} reason
+ */
 export async function notifyCosmoEscalation(ticketId, reason) {
-  logger.info(`Cosmo escalation for ticket ${ticketId}: ${reason}`);
+  try {
+    await axios.post(`${COSMO_URL}/v1/escalate`, { ticketId, reason });
+    logger.info(`Cosmo escalation for ticket ${ticketId}: ${reason}`);
+  } catch (err) {
+    logger.error('Failed to notify Cosmo escalation', err);
+  }
 }

--- a/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
+++ b/apps/pulse/nova-pulse/src/components/CosmoAssistant.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Button } from '@nova-universe/ui'
+import { sendCosmoMessage } from '../lib/api'
 
 export const CosmoAssistant: React.FC = () => {
   const [messages, setMessages] = useState<{ from: string; text: string }[]>([])
@@ -10,11 +11,21 @@ export const CosmoAssistant: React.FC = () => {
     if (!input.trim()) return
     setLoading(true)
     setMessages(msgs => [...msgs, { from: 'user', text: input }])
-    // TODO: integrate real Cosmo SDK
-    setTimeout(() => {
-      setMessages(msgs => [...msgs, { from: 'cosmo', text: 'This is a placeholder response from Cosmo.' }])
+
+    const token = typeof window !== 'undefined' ? localStorage.getItem('token') || '' : ''
+
+    try {
+      const res = await sendCosmoMessage(token, input)
+      if (res.success) {
+        setMessages(msgs => [...msgs, { from: 'cosmo', text: res.message }])
+      } else {
+        setMessages(msgs => [...msgs, { from: 'cosmo', text: 'Sorry, something went wrong.' }])
+      }
+    } catch (err) {
+      setMessages(msgs => [...msgs, { from: 'cosmo', text: 'Sorry, something went wrong.' }])
+    } finally {
       setLoading(false)
-    }, RESPONSE_DELAY)
+    }
     setInput('')
   }
 

--- a/apps/pulse/nova-pulse/src/lib/api.ts
+++ b/apps/pulse/nova-pulse/src/lib/api.ts
@@ -57,3 +57,11 @@ export const getXpLeaderboard = async () => {
   const { data } = await client.get<{ success: boolean; leaderboard: LeaderboardEntry[]; teams: TeamRanking[]; me: { xp: number } }>('/xp')
   return data
 }
+
+export const sendCosmoMessage = async (token: string, message: string) => {
+  const { data } = await axios.post('/api/v1/synth/chat', { message }, {
+    headers: { Authorization: `Bearer ${token}` },
+    withCredentials: true
+  })
+  return data
+}


### PR DESCRIPTION
## Summary
- connect Pulse Cosmo assistant component to backend
- add cosmo API helper for Pulse frontend
- implement Cosmo message utilities on server
- wire escalation hooks for VIP tickets
- expose COSMO_API_URL in config

## Testing
- `npm test` *(fails: Must use import to load ES Module)*

------
https://chatgpt.com/codex/tasks/task_e_688ab19b4ad88333b301097cb412d3ad