### PR TITLE
Add basic GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: npm test


### PR DESCRIPTION
## Summary
- add a CI workflow to run the project's tests using pnpm and Node 18

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ad76dbc048333a051e536e94ecd5f