### PR TITLE
Add module management page

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -13,6 +13,7 @@ import logsRouter from './routes/logs.js'; // Import logsRouter
 import reportsRouter from './routes/reports.js';
 import vipRouter from './routes/vip.js';
 import workflowsRouter from './routes/workflows.js';
+import modulesRouter from './routes/modules.js';
 // Nova module routes
 import { Strategy as SamlStrategy } from '@node-saml/passport-saml';
 import {
@@ -1267,6 +1268,7 @@ app.use('/api/v1/logs', logsRouter); // Register logsRouter
 app.use('/api/reports', reportsRouter);
 app.use('/api/v1/vip', vipRouter);
 app.use('/api/workflows', workflowsRouter);
+app.use('/api/v1/modules', modulesRouter);
 
 // Nova module routes
 app.use('/api/v1/helix', helixRouter);     // Nova Helix - Identity Engine

--- a/apps/api/routes/modules.js
+++ b/apps/api/routes/modules.js
@@ -1,0 +1,87 @@
+import express from 'express';
+import ConfigurationManager from '../config/app-settings.js';
+import { authenticateJWT } from '../middleware/auth.js';
+import { createRateLimit } from '../middleware/rateLimiter.js';
+import { body, validationResult } from 'express-validator';
+import { logger } from '../logger.js';
+
+const router = express.Router();
+
+// Get list of modules (feature toggles)
+router.get('/',
+  authenticateJWT,
+  createRateLimit(15 * 60 * 1000, 30),
+  async (req, res) => {
+    try {
+      if (!req.user?.roles?.includes('admin') && !req.user?.roles?.includes('superadmin')) {
+        return res.status(403).json({
+          success: false,
+          error: 'Admin access required',
+          errorCode: 'ADMIN_ACCESS_REQUIRED'
+        });
+      }
+
+      const features = await ConfigurationManager.get('features');
+      res.json({ success: true, modules: features || {} });
+    } catch (error) {
+      logger.error('Error getting modules:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to get modules',
+        errorCode: 'MODULES_ERROR'
+      });
+    }
+  }
+);
+
+// Update a single module
+router.put('/:key',
+  authenticateJWT,
+  createRateLimit(15 * 60 * 1000, 20),
+  [body('enabled').isBoolean()],
+  async (req, res) => {
+    try {
+      if (!req.user?.roles?.includes('admin') && !req.user?.roles?.includes('superadmin')) {
+        return res.status(403).json({
+          success: false,
+          error: 'Admin access required',
+          errorCode: 'ADMIN_ACCESS_REQUIRED'
+        });
+      }
+
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({
+          success: false,
+          error: 'Invalid input',
+          details: errors.array(),
+          errorCode: 'VALIDATION_ERROR'
+        });
+      }
+
+      const { key } = req.params;
+      const { enabled } = req.body;
+      const features = await ConfigurationManager.get('features') || {};
+      features[key] = enabled;
+      const success = await ConfigurationManager.set('features', features, req.user.id);
+      if (!success) {
+        return res.status(500).json({
+          success: false,
+          error: 'Failed to update module',
+          errorCode: 'MODULE_UPDATE_FAILED'
+        });
+      }
+
+      res.json({ success: true, message: 'Module updated', key, enabled });
+    } catch (error) {
+      logger.error('Error updating module:', error);
+      res.status(500).json({
+        success: false,
+        error: 'Failed to update module',
+        errorCode: 'MODULE_UPDATE_ERROR'
+      });
+    }
+  }
+);
+
+export default router;

--- a/apps/core/nova-core/src/App.tsx
+++ b/apps/core/nova-core/src/App.tsx
@@ -23,7 +23,8 @@ const AnalyticsPage = React.lazy(() => import('@/pages/AnalyticsPage').then(m =>
 const NotificationsPage = React.lazy(() => import('@/pages/NotificationsPage').then(m => ({ default: m.NotificationsPage })));
 const SettingsPage = React.lazy(() => import('@/pages/SettingsPage').then(m => ({ default: m.SettingsPage })));
 const IntegrationsPage = React.lazy(() => import('@/pages/IntegrationsPage').then(m => ({ default: m.IntegrationsPage })));
-const KioskActivationPage = React.lazy(() => import('@/pages/KioskActivationPage').then(m => ({ default: m.KioskActivationPage })));
+const ModuleManagementPage = React.lazy(() => import('@/pages/ModuleManagementPage').then(m => ({ default: m.ModuleManagementPage })));
+const KioskActivationPage = React.lazy(() => import('@/pages/KioskActivationPage').then(m => ({ default: m.KioskActivationPage }))); 
 const CatalogItemsPage = React.lazy(() => import('@/pages/CatalogItemsPage').then(m => ({ default: m.CatalogItemsPage })));
 const KnowledgeListPage = React.lazy(() => import('@/pages/knowledge/KnowledgeListPage').then(m => ({ default: m.default })));
 const KnowledgeDetailPage = React.lazy(() => import('@/pages/knowledge/KnowledgeDetailPage').then(m => ({ default: m.default })));
@@ -178,6 +179,14 @@ const AppRoutes: React.FC = () => {
           element={
             <React.Suspense fallback={<div>Loading...</div>}>
               <IntegrationsPage />
+            </React.Suspense>
+          }
+        />
+        <Route
+          path="modules"
+          element={
+            <React.Suspense fallback={<div>Loading...</div>}>
+              <ModuleManagementPage />
             </React.Suspense>
           }
         />

--- a/apps/core/nova-core/src/components/layout/Sidebar.tsx
+++ b/apps/core/nova-core/src/components/layout/Sidebar.tsx
@@ -26,6 +26,7 @@ const navigation = [
   { name: 'Analytics', href: '/analytics', icon: ChartBarIcon },
   { name: 'Notifications', href: '/notifications', icon: BellIcon },
   { name: 'Integrations', href: '/integrations', icon: Cog6ToothIcon },
+  { name: 'Modules', href: '/modules', icon: Cog6ToothIcon },
   { name: 'Settings', href: '/settings', icon: CogIcon },
 ];
 

--- a/apps/core/nova-core/src/lib/api.ts
+++ b/apps/core/nova-core/src/lib/api.ts
@@ -27,6 +27,7 @@ import {
   mockLogs,
   mockConfig,
   mockIntegrations,
+  mockModules,
   mockRoles,
   mockPermissions,
   mockNotifications,
@@ -558,6 +559,26 @@ class ApiClient {
     }
 
     const response = await this.client.post<ApiResponse>(`/api/integrations/${id}/test`);
+    return response.data;
+  }
+
+  // Modules
+  async getModules(): Promise<Record<string, boolean>> {
+    if (this.useMockMode) {
+      return this.mockRequest(mockModules);
+    }
+
+    const response = await this.client.get<{ modules: Record<string, boolean> }>('/api/modules');
+    return response.data.modules;
+  }
+
+  async updateModule(key: string, enabled: boolean): Promise<ApiResponse> {
+    if (this.useMockMode) {
+      mockModules[key] = enabled;
+      return this.mockRequest({ message: 'Module updated' });
+    }
+
+    const response = await this.client.put<ApiResponse>(`/api/modules/${key}`, { enabled });
     return response.data;
   }
 

--- a/apps/core/nova-core/src/lib/mockData.ts
+++ b/apps/core/nova-core/src/lib/mockData.ts
@@ -1,4 +1,5 @@
 import type { User, Kiosk, Log, Config, Notification, Integration, DashboardStats, Role, Permission } from '@/types';
+import type { ModuleStatus } from '@/types';
 
 // Mock data for development when API is not available
 export const mockUsers: User[] = [
@@ -183,6 +184,14 @@ export const mockIntegrations: Integration[] = [
     working: true
   }
 ];
+
+export const mockModules: Record<string, boolean> = {
+  pulse: true,
+  orbit: true,
+  comms: false,
+  beacon: true,
+  synth: false,
+};
 
 export const mockRoles: Role[] = [
   { id: 1, name: 'admin' },

--- a/apps/core/nova-core/src/pages/ModuleManagementPage.d.ts
+++ b/apps/core/nova-core/src/pages/ModuleManagementPage.d.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+export declare const ModuleManagementPage: React.FC;
+//# sourceMappingURL=ModuleManagementPage.d.ts.map

--- a/apps/core/nova-core/src/pages/ModuleManagementPage.tsx
+++ b/apps/core/nova-core/src/pages/ModuleManagementPage.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Switch } from '@/components/ui';
+import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import { api } from '@/lib/api';
+import { useToastStore } from '@/stores/toast';
+
+interface Module {
+  key: string;
+  enabled: boolean;
+}
+
+export const ModuleManagementPage: React.FC = () => {
+  const [modules, setModules] = useState<Module[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { addToast } = useToastStore();
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const load = async () => {
+    try {
+      setLoading(true);
+      const data = await api.getModules();
+      const list = Object.entries(data).map(([key, enabled]) => ({ key, enabled }));
+      setModules(list);
+    } catch (err) {
+      console.error(err);
+      addToast({ type: 'error', title: 'Error', description: 'Failed to load modules' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const update = async (key: string, enabled: boolean) => {
+    try {
+      await api.updateModule(key, enabled);
+      setModules(mods => mods.map(m => (m.key === key ? { ...m, enabled } : m)));
+      addToast({ type: 'success', title: 'Updated', description: `Module ${key} ${enabled ? 'enabled' : 'disabled'}` });
+    } catch (err) {
+      console.error(err);
+      addToast({ type: 'error', title: 'Error', description: 'Failed to update module' });
+    }
+  };
+
+  const getStatusIcon = (enabled: boolean) => (
+    enabled ? <CheckCircleIcon className="h-5 w-5 text-green-500" /> : <XCircleIcon className="h-5 w-5 text-gray-400" />
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">Module Management</h1>
+        <p className="mt-1 text-sm text-gray-600">Enable or disable Nova modules for your tenant.</p>
+      </div>
+
+      <Card>
+        {loading ? (
+          <div className="flex items-center justify-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600"></div>
+          </div>
+        ) : (
+          <div className="divide-y divide-gray-200">
+            {modules.map(mod => (
+              <div key={mod.key} className="flex items-center justify-between p-4">
+                <div className="flex items-center space-x-3">
+                  {getStatusIcon(mod.enabled)}
+                  <span className="font-medium text-gray-900">{mod.key}</span>
+                </div>
+                <Switch checked={mod.enabled} onChange={checked => update(mod.key, checked)} />
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -505,3 +505,8 @@ export interface SCIMConfig {
   };
   groupMapping?: Record<string, string>;
 }
+
+export interface ModuleStatus {
+  key: string;
+  enabled: boolean;
+}


### PR DESCRIPTION
## Summary
- add API endpoints to list and update modules
- expose module APIs in frontend client
- create `ModuleManagementPage` for enabling modules per tenant
- register route and navigation entry

## Testing
- `npm run lint` *(fails: 146 errors)*
- `npm test`
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_688ae04d882c8333b82583783e4b7e9c