### PR TITLE
Expose organization name setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ See [Local vs Production Setup](docs/environments.md) for details on configuring
    `HELPSCOUT_API_KEY` and `HELPSCOUT_MAILBOX_ID` (optionally set
    `HELPSCOUT_SMTP_FALLBACK=true` to also send email).
    **Note:** ServiceNow integration has been fully deprecated and removed.
-   You can customize `API_PORT`, `LOGO_URL` and other defaults.
+   You can customize `API_PORT`, `LOGO_URL`, `FAVICON_URL` and `ORGANIZATION_NAME`.
 4. Start the server with `node index.js` (uses `API_PORT`, default `3000`).
 
 The API also exposes a GraphQL endpoint at `/api/v2/graphql` for internal tools.
@@ -340,7 +340,7 @@ Each app relies on a few environment variables:
 - `HELPSCOUT_SMTP_FALLBACK` – set to `true` to also send email via SMTP.
 - `SESSION_SECRET`, `SAML_ENTRY_POINT`, `SAML_ISSUER`, `SAML_CERT`,
   `SAML_CALLBACK_URL`, `ADMIN_URL` – required for SAML login.
-- Optional: `API_PORT` (default `3000`), `LOGO_URL`, `FAVICON_URL`.
+ - Optional: `API_PORT` (default `3000`), `LOGO_URL`, `FAVICON_URL`, `ORGANIZATION_NAME`.
 - Optional: set `TLS_CERT_PATH` and `TLS_KEY_PATH` to enable HTTPS.
 - `ADMIN_PASSWORD` – seeds the initial admin password for kiosk login and the
   password management endpoints.

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -558,6 +558,7 @@ v1Router.get('/config', ensureAuth, (req, res) => {
     const defaults = {
       logoUrl: '/logo.png',
       faviconUrl: '/vite.svg',
+      organizationName: 'Your Organization',
       welcomeMessage: 'Welcome to the Help Desk',
       helpMessage: 'Need to report an issue?',
       statusOpenMsg: 'Open',
@@ -574,6 +575,7 @@ v1Router.get('/config', ensureAuth, (req, res) => {
     const envConfig = {
       logoUrl: process.env.LOGO_URL,
       faviconUrl: process.env.FAVICON_URL,
+      organizationName: process.env.ORGANIZATION_NAME,
       welcomeMessage: process.env.WELCOME_MESSAGE,
       helpMessage: process.env.HELP_MESSAGE,
       statusOpenMsg: process.env.STATUS_OPEN_MSG,
@@ -609,9 +611,39 @@ v1Router.put('/api/config', ensureAuth, (req, res) => {
         const dbConfig = Object.fromEntries(rows.map((r) => [r.key, r.value]));
         delete dbConfig.adminPassword;
 
-        const defaults = DEFAULT_CONFIG;
+        const defaults = {
+          logoUrl: '/logo.png',
+          faviconUrl: '/vite.svg',
+          organizationName: 'Your Organization',
+          welcomeMessage: 'Welcome to the Help Desk',
+          helpMessage: 'Need to report an issue?',
+          statusOpenMsg: 'Open',
+          statusClosedMsg: 'Closed',
+          statusErrorMsg: 'Error',
+          statusMeetingMsg: 'In a Meeting - Back Soon',
+          statusBrbMsg: 'Be Right Back',
+          statusLunchMsg: 'Out to Lunch - Back in 1 Hour',
+          statusUnavailableMsg: 'Status Unavailable',
+          rateLimitWindow: '900000',
+          rateLimitMax: '100'
+        };
 
-        const envConfig = getEnvConfig();
+        const envConfig = {
+          logoUrl: process.env.LOGO_URL,
+          faviconUrl: process.env.FAVICON_URL,
+          organizationName: process.env.ORGANIZATION_NAME,
+          welcomeMessage: process.env.WELCOME_MESSAGE,
+          helpMessage: process.env.HELP_MESSAGE,
+          statusOpenMsg: process.env.STATUS_OPEN_MSG,
+          statusClosedMsg: process.env.STATUS_CLOSED_MSG,
+          statusErrorMsg: process.env.STATUS_ERROR_MSG,
+          statusMeetingMsg: process.env.STATUS_MEETING_MSG,
+          statusBrbMsg: process.env.STATUS_BRB_MSG,
+          statusLunchMsg: process.env.STATUS_LUNCH_MSG,
+          statusUnavailableMsg: process.env.STATUS_UNAVAILABLE_MSG,
+          rateLimitWindow: process.env.RATE_LIMIT_WINDOW,
+          rateLimitMax: process.env.RATE_LIMIT_MAX
+        };
 
         const config = { ...defaults, ...dbConfig, ...envConfig };
         res.json(config);

--- a/apps/core/nova-core/src/lib/mockData.ts
+++ b/apps/core/nova-core/src/lib/mockData.ts
@@ -136,6 +136,7 @@ export const mockLogs: Log[] = [
 ];
 
 export const mockConfig: Config = {
+  organizationName: 'CueIT',
   logoUrl: 'https://via.placeholder.com/200x60/3B82F6/FFFFFF?text=CueIT',
   faviconUrl: 'https://via.placeholder.com/32x32/3B82F6/FFFFFF?text=C',
   primaryColor: '#1D4ED8',

--- a/apps/core/nova-core/src/pages/SettingsPage.tsx
+++ b/apps/core/nova-core/src/pages/SettingsPage.tsx
@@ -372,6 +372,15 @@ export const SettingsPage: React.FC = () => {
                   </div>
 
                   <div className="grid grid-cols-1 gap-6">
+                    <Input
+                      label="Organization Name"
+                      value={config?.organizationName || ''}
+                      onChange={(e) =>
+                        setConfig(prev => prev ? { ...prev, organizationName: e.target.value } : null)
+                      }
+                      helperText="Displayed across the admin interface"
+                    />
+
                     {/* Logo Upload */}
                     <div>
                       <FileInput

--- a/apps/core/nova-core/src/types/index.d.ts
+++ b/apps/core/nova-core/src/types/index.d.ts
@@ -84,6 +84,7 @@ export interface Log {
     emailStatus: 'success' | 'fail';
 }
 export interface Config {
+    organizationName: string;
     logoUrl: string;
     faviconUrl: string;
     kioskLogoUrl?: string;

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -99,6 +99,7 @@ export interface Log {
 }
 
 export interface Config {
+  organizationName: string;
   logoUrl: string;
   faviconUrl: string;
   kioskLogoUrl?: string;


### PR DESCRIPTION
## Summary
- expose `organizationName` through admin config API
- allow editing organization name in admin UI
- document ORGANIZATION_NAME environment variable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ae0705da4833399feabcc479c4eb7