### PR TITLE
Add API Docs hub

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -14,6 +14,7 @@ import reportsRouter from './routes/reports.js';
 import vipRouter from './routes/vip.js';
 import workflowsRouter from './routes/workflows.js';
 import modulesRouter from './routes/modules.js';
+import apiKeysRouter from './routes/apiKeys.js';
 // Nova module routes
 import { Strategy as SamlStrategy } from '@node-saml/passport-saml';
 import {
@@ -1286,6 +1287,7 @@ app.use('/api/reports', reportsRouter);
 app.use('/api/v1/vip', vipRouter);
 app.use('/api/workflows', workflowsRouter);
 app.use('/api/v1/modules', modulesRouter);
+app.use('/api/v1/api-keys', apiKeysRouter);
 
 // Nova module routes
 app.use('/api/v1/helix', helixRouter);     // Nova Helix - Identity Engine

--- a/apps/api/routes/apiKeys.js
+++ b/apps/api/routes/apiKeys.js
@@ -37,13 +37,14 @@ router.post('/',
         return res.status(400).json({ success: false, error: 'Invalid input', details: errors.array(), errorCode: 'VALIDATION_ERROR' });
       }
       const key = uuidv4();
+      const createdAt = new Date().toISOString();
       const apiKeys = await ConfigurationManager.get('apiKeys', []);
-      apiKeys.push({ key, description: req.body.description || '', createdAt: new Date().toISOString() });
+      apiKeys.push({ key, description: req.body.description || '', createdAt });
       const success = await ConfigurationManager.set('apiKeys', apiKeys, req.user.id);
       if (!success) {
         return res.status(500).json({ success: false, error: 'Failed to save API key', errorCode: 'API_KEYS_SAVE_ERROR' });
       }
-      res.json({ success: true, apiKey: { key, createdAt: new Date().toISOString(), description: req.body.description || '' } });
+      res.json({ success: true, apiKey: { key, createdAt, description: req.body.description || '' } });
     } catch (err) {
       logger.error('Error creating API key:', err);
       res.status(500).json({ success: false, error: 'Failed to create API key', errorCode: 'API_KEYS_ERROR' });

--- a/apps/api/routes/apiKeys.js
+++ b/apps/api/routes/apiKeys.js
@@ -1,0 +1,75 @@
+import express from 'express';
+import { authenticateJWT } from '../middleware/auth.js';
+import { createRateLimit } from '../middleware/rateLimiter.js';
+import { body, validationResult } from 'express-validator';
+import { v4 as uuidv4 } from 'uuid';
+import ConfigurationManager from '../config/app-settings.js';
+import { logger } from '../logger.js';
+
+const router = express.Router();
+
+// List API keys
+router.get('/', authenticateJWT, createRateLimit(15 * 60 * 1000, 30), async (req, res) => {
+  try {
+    if (!req.user?.roles?.includes('admin') && !req.user?.roles?.includes('superadmin')) {
+      return res.status(403).json({ success: false, error: 'Admin access required', errorCode: 'ADMIN_ACCESS_REQUIRED' });
+    }
+    const apiKeys = await ConfigurationManager.get('apiKeys', []);
+    res.json({ success: true, apiKeys });
+  } catch (err) {
+    logger.error('Error getting API keys:', err);
+    res.status(500).json({ success: false, error: 'Failed to get API keys', errorCode: 'API_KEYS_ERROR' });
+  }
+});
+
+// Create API key
+router.post('/',
+  authenticateJWT,
+  createRateLimit(15 * 60 * 1000, 10),
+  [body('description').optional().isString()],
+  async (req, res) => {
+    try {
+      if (!req.user?.roles?.includes('admin') && !req.user?.roles?.includes('superadmin')) {
+        return res.status(403).json({ success: false, error: 'Admin access required', errorCode: 'ADMIN_ACCESS_REQUIRED' });
+      }
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ success: false, error: 'Invalid input', details: errors.array(), errorCode: 'VALIDATION_ERROR' });
+      }
+      const key = uuidv4();
+      const apiKeys = await ConfigurationManager.get('apiKeys', []);
+      apiKeys.push({ key, description: req.body.description || '', createdAt: new Date().toISOString() });
+      const success = await ConfigurationManager.set('apiKeys', apiKeys, req.user.id);
+      if (!success) {
+        return res.status(500).json({ success: false, error: 'Failed to save API key', errorCode: 'API_KEYS_SAVE_ERROR' });
+      }
+      res.json({ success: true, apiKey: { key, createdAt: new Date().toISOString(), description: req.body.description || '' } });
+    } catch (err) {
+      logger.error('Error creating API key:', err);
+      res.status(500).json({ success: false, error: 'Failed to create API key', errorCode: 'API_KEYS_ERROR' });
+    }
+  });
+
+// Delete API key
+router.delete('/:key', authenticateJWT, createRateLimit(15 * 60 * 1000, 10), async (req, res) => {
+  try {
+    if (!req.user?.roles?.includes('admin') && !req.user?.roles?.includes('superadmin')) {
+      return res.status(403).json({ success: false, error: 'Admin access required', errorCode: 'ADMIN_ACCESS_REQUIRED' });
+    }
+    const apiKeys = await ConfigurationManager.get('apiKeys', []);
+    const filtered = apiKeys.filter(k => k.key !== req.params.key);
+    if (filtered.length === apiKeys.length) {
+      return res.status(404).json({ success: false, error: 'API key not found', errorCode: 'API_KEY_NOT_FOUND' });
+    }
+    const success = await ConfigurationManager.set('apiKeys', filtered, req.user.id);
+    if (!success) {
+      return res.status(500).json({ success: false, error: 'Failed to delete API key', errorCode: 'API_KEYS_SAVE_ERROR' });
+    }
+    res.json({ success: true, message: 'API key deleted' });
+  } catch (err) {
+    logger.error('Error deleting API key:', err);
+    res.status(500).json({ success: false, error: 'Failed to delete API key', errorCode: 'API_KEYS_ERROR' });
+  }
+});
+
+export default router;

--- a/apps/core/nova-core/src/App.tsx
+++ b/apps/core/nova-core/src/App.tsx
@@ -23,12 +23,13 @@ const AnalyticsPage = React.lazy(() => import('@/pages/AnalyticsPage').then(m =>
 const NotificationsPage = React.lazy(() => import('@/pages/NotificationsPage').then(m => ({ default: m.NotificationsPage })));
 const SettingsPage = React.lazy(() => import('@/pages/SettingsPage').then(m => ({ default: m.SettingsPage })));
 const IntegrationsPage = React.lazy(() => import('@/pages/IntegrationsPage').then(m => ({ default: m.IntegrationsPage })));
-const ModuleManagementPage = React.lazy(() => import('@/pages/ModuleManagementPage').then(m => ({ default: m.ModuleManagementPage })));
+const ModuleManagementPage = React.lazy(() => import('@/pages/ModuleManagementPage').then(m => ({ default: m.ModuleManagementPage }))); 
 const KioskActivationPage = React.lazy(() => import('@/pages/KioskActivationPage').then(m => ({ default: m.KioskActivationPage }))); 
-const CatalogItemsPage = React.lazy(() => import('@/pages/CatalogItemsPage').then(m => ({ default: m.CatalogItemsPage })));
-const KnowledgeListPage = React.lazy(() => import('@/pages/knowledge/KnowledgeListPage').then(m => ({ default: m.default })));
-const KnowledgeDetailPage = React.lazy(() => import('@/pages/knowledge/KnowledgeDetailPage').then(m => ({ default: m.default })));
+const CatalogItemsPage = React.lazy(() => import('@/pages/CatalogItemsPage').then(m => ({ default: m.CatalogItemsPage }))); 
+const KnowledgeListPage = React.lazy(() => import('@/pages/knowledge/KnowledgeListPage').then(m => ({ default: m.default }))); 
+const KnowledgeDetailPage = React.lazy(() => import('@/pages/knowledge/KnowledgeDetailPage').then(m => ({ default: m.default }))); 
 const KnowledgeEditPage = React.lazy(() => import('@/pages/knowledge/KnowledgeEditPage').then(m => ({ default: m.default })));
+const APIDocumentationPage = React.lazy(() => import('@/pages/APIDocumentationPage').then(m => ({ default: m.APIDocumentationPage })));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -187,6 +188,14 @@ const AppRoutes: React.FC = () => {
           element={
             <React.Suspense fallback={<div>Loading...</div>}>
               <ModuleManagementPage />
+            </React.Suspense>
+          }
+        />
+        <Route
+          path="api-docs"
+          element={
+            <React.Suspense fallback={<div>Loading...</div>}>
+              <APIDocumentationPage />
             </React.Suspense>
           }
         />

--- a/apps/core/nova-core/src/App.tsx
+++ b/apps/core/nova-core/src/App.tsx
@@ -29,7 +29,7 @@ const CatalogItemsPage = React.lazy(() => import('@/pages/CatalogItemsPage').the
 const KnowledgeListPage = React.lazy(() => import('@/pages/knowledge/KnowledgeListPage').then(m => ({ default: m.default }))); 
 const KnowledgeDetailPage = React.lazy(() => import('@/pages/knowledge/KnowledgeDetailPage').then(m => ({ default: m.default }))); 
 const KnowledgeEditPage = React.lazy(() => import('@/pages/knowledge/KnowledgeEditPage').then(m => ({ default: m.default })));
-const APIDocumentationPage = React.lazy(() => import('@/pages/APIDocumentationPage').then(m => ({ default: m.APIDocumentationPage })));
+const APIDocumentationPage = React.lazy(() => import('@/pages/APIDocumentationPage').then(m => ({ default: m.default })));
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/apps/core/nova-core/src/lib/api.d.ts
+++ b/apps/core/nova-core/src/lib/api.d.ts
@@ -1,4 +1,4 @@
-import type { User, Role, Permission, Kiosk, Log, Config, Notification, DirectoryUser, Integration, KioskActivation, KioskConfig, Asset, ApiResponse, LoginCredentials, AuthToken, DashboardStats, ActivityLog } from '@/types';
+import type { User, Role, Permission, Kiosk, Log, Config, Notification, DirectoryUser, Integration, KioskActivation, KioskConfig, Asset, ApiResponse, LoginCredentials, AuthToken, DashboardStats, ActivityLog, ApiKey } from '@/types';
 declare class ApiClient {
     private client;
     private useMockMode;
@@ -110,6 +110,9 @@ declare class ApiClient {
     }): Promise<ApiResponse>;
     getKioskScheduleConfig(kioskId: string): Promise<any>;
     testSMTP(testEmail: string): Promise<ApiResponse>;
+    getApiKeys(): Promise<ApiKey[]>;
+    createApiKey(description?: string): Promise<{ apiKey: ApiKey }>;
+    deleteApiKey(key: string): Promise<ApiResponse>;
 }
 export declare const api: ApiClient;
 export {};

--- a/apps/core/nova-core/src/lib/api.ts
+++ b/apps/core/nova-core/src/lib/api.ts
@@ -15,6 +15,7 @@ import type {
   Asset,
   KnowledgeArticle,
   KnowledgeArticleVersion,
+  ApiKey,
   ApiResponse,
   LoginCredentials,
   AuthToken,
@@ -1307,6 +1308,22 @@ class ApiClient {
   async createKnowledgeVersion(articleId: number, data: { content: string }): Promise<KnowledgeArticleVersion> {
     const response = await this.client.post<{ version: KnowledgeArticleVersion }>(`/api/v1/lore/articles/${articleId}/versions`, data);
     return response.data.version;
+  }
+
+  // API Keys
+  async getApiKeys(): Promise<ApiKey[]> {
+    const response = await this.client.get<{ apiKeys: ApiKey[] }>('/api/v1/api-keys');
+    return response.data.apiKeys;
+  }
+
+  async createApiKey(description?: string): Promise<{ apiKey: ApiKey }> {
+    const response = await this.client.post<{ apiKey: ApiKey }>('/api/v1/api-keys', { description });
+    return response.data;
+  }
+
+  async deleteApiKey(key: string): Promise<ApiResponse> {
+    const response = await this.client.delete<ApiResponse>(`/api/v1/api-keys/${key}`);
+    return response.data;
   }
 }
 

--- a/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
+++ b/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
@@ -23,8 +23,12 @@ export const APIDocumentationPage: React.FC = () => {
   useEffect(() => { load(); }, []);
 
   const createKey = async () => {
-    const { apiKey } = await api.createApiKey();
-    setKeys(prev => [...prev, apiKey]);
+    try {
+      const { apiKey } = await api.createApiKey();
+      setKeys(prev => [...prev, apiKey]);
+    } catch (err) {
+      console.error("Failed to create API key:", err);
+    }
   };
 
   const deleteKey = async (key: string) => {

--- a/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
+++ b/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
@@ -32,8 +32,13 @@ export const APIDocumentationPage: React.FC = () => {
   };
 
   const deleteKey = async (key: string) => {
-    await api.deleteApiKey(key);
-    setKeys(prev => prev.filter(k => k.key !== key));
+    try {
+      await api.deleteApiKey(key);
+      setKeys(prev => prev.filter(k => k.key !== key));
+    } catch (err) {
+      console.error("Failed to delete API key:", err);
+      alert("An error occurred while deleting the API key. Please try again.");
+    }
   };
 
   return (

--- a/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
+++ b/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from 'react';
+import { Card, Button } from '@/components/ui';
+import { api } from '@/lib/api';
+import { getEnv } from '@/lib/env';
+import type { ApiKey } from '@/types';
+
+export const APIDocumentationPage: React.FC = () => {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { apiUrl } = getEnv();
+
+  const load = async () => {
+    try {
+      const data = await api.getApiKeys();
+      setKeys(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, []);
+
+  const createKey = async () => {
+    const { apiKey } = await api.createApiKey();
+    setKeys(prev => [...prev, apiKey]);
+  };
+
+  const deleteKey = async (key: string) => {
+    await api.deleteApiKey(key);
+    setKeys(prev => prev.filter(k => k.key !== key));
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-gray-900">API Documentation</h1>
+        <p className="mt-1 text-sm text-gray-600">Explore the Nova Universe API and manage your API keys.</p>
+      </div>
+      <Card className="p-4">
+        <iframe src={`${apiUrl}/api-docs`} title="API Docs" className="w-full h-[600px] border rounded" />
+      </Card>
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">API Keys</h2>
+          <Button onClick={createKey}>Generate Key</Button>
+        </div>
+        {loading ? (
+          <div className="text-sm text-gray-500">Loading...</div>
+        ) : (
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr><th className="px-2 py-1 text-left">Key</th><th className="px-2 py-1 text-left">Created</th><th></th></tr>
+            </thead>
+            <tbody>
+              {keys.map(k => (
+                <tr key={k.key}>
+                  <td className="border px-2 py-1 font-mono break-all">{k.key}</td>
+                  <td className="border px-2 py-1">{new Date(k.createdAt).toLocaleString()}</td>
+                  <td className="border px-2 py-1 text-right">
+                    <Button variant="secondary" size="sm" onClick={() => deleteKey(k.key)}>Delete</Button>
+                  </td>
+                </tr>
+              ))}
+              {keys.length === 0 && (
+                <tr><td colSpan={3} className="text-center p-2 text-gray-500">No API keys</td></tr>
+              )}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default APIDocumentationPage;

--- a/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
+++ b/apps/core/nova-core/src/pages/APIDocumentationPage.tsx
@@ -48,7 +48,7 @@ export const APIDocumentationPage: React.FC = () => {
         <p className="mt-1 text-sm text-gray-600">Explore the Nova Universe API and manage your API keys.</p>
       </div>
       <Card className="p-4">
-        <iframe src={`${apiUrl}/api-docs`} title="API Docs" className="w-full h-[600px] border rounded" />
+        <iframe src={`${apiUrl}/api-docs`} title="API Docs" className="w-full h-[600px] border rounded" sandbox="allow-scripts allow-same-origin" />
       </Card>
       <Card className="p-4">
         <div className="flex items-center justify-between mb-2">

--- a/apps/core/nova-core/src/types/index.ts
+++ b/apps/core/nova-core/src/types/index.ts
@@ -511,3 +511,9 @@ export interface ModuleStatus {
   key: string;
   enabled: boolean;
 }
+
+export interface ApiKey {
+  key: string;
+  createdAt: string;
+  description?: string;
+}


### PR DESCRIPTION
## Summary
- implement API key management API endpoints
- expose `/api-docs` with new APIDocumentationPage
- wire API docs route into main app
- extend API client and types for API key support

## Testing
- `npm test`
- `npm run type-check` *(shows tsc help)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_688bb1db7ec883339c42b1c12b47f617