### PR TITLE
Resolve lint errors in API and core pages

### DIFF
--- a/apps/api/cli/commands/backup.js
+++ b/apps/api/cli/commands/backup.js
@@ -273,14 +273,14 @@ async function backupDatabase(backupPath) {
       for (const collection of collections) {
         try {
           data[collection] = await db.collection(collection).find({}).toArray();
-        } catch (err) {
+        } catch {
           // Collection might not exist
           data[collection] = [];
         }
       }
       
       require('fs').writeFileSync(dbBackupPath, JSON.stringify(data, null, 2));
-    } catch (fallbackError) {
+    } catch {
       throw new Error(`Database backup failed: ${error.message}`);
     }
   }
@@ -399,7 +399,7 @@ async function listBackups(options) {
           const manifest = JSON.parse(require('fs').readFileSync(manifestPath, 'utf8'));
           backup.manifest = manifest;
         }
-      } catch (err) {
+      } catch {
         // Manifest not readable, continue
       }
 
@@ -440,7 +440,7 @@ async function listBackups(options) {
 // Restore backup
 async function restoreBackup(backupName, options) {
   const projectRoot = getProjectRoot();
-  const backupPath = path.resolve(backupName);
+  let backupPath = path.resolve(backupName);
 
   if (!existsSync(backupPath)) {
     // Try in backups directory
@@ -696,7 +696,7 @@ async function showBackupInfo(backupName, options) {
     if (existsSync(manifestPath)) {
       try {
         info.manifest = JSON.parse(require('fs').readFileSync(manifestPath, 'utf8'));
-      } catch (err) {
+      } catch {
         // Manifest not readable
       }
     }
@@ -879,7 +879,7 @@ async function getFolderSize(folderPath) {
   try {
     const { stdout } = await runCommand('du', ['-sb', folderPath], { silent: true });
     return parseInt(stdout.split('\t')[0]);
-  } catch (error) {
+  } catch {
     return 0;
   }
 }

--- a/apps/api/cli/commands/dashboard.js
+++ b/apps/api/cli/commands/dashboard.js
@@ -8,15 +8,13 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import path from 'path';
-import { existsSync, readFileSync } from 'fs';
-import { 
-  logger, 
-  createSpinner, 
+import { existsSync } from 'fs';
+import {
+  logger,
+  createSpinner,
   getProjectRoot,
   checkServiceStatus,
-  connectDatabase,
-  formatFileSize,
-  formatDuration
+  connectDatabase
 } from '../utils/index.js';
 
 export const dashboardCommand = new Command('dashboard')
@@ -107,7 +105,7 @@ async function startDashboard(options) {
       try {
         const { default: open } = await import('open');
         await open(dashboardUrl);
-      } catch (error) {
+      } catch {
         console.log(chalk.yellow('Could not open browser automatically'));
         console.log(chalk.gray(`Please open ${dashboardUrl} manually`));
       }
@@ -332,7 +330,7 @@ async function getRecentLogs(service, lines) {
           }));
 
         logs.push(...logLines);
-      } catch (error) {
+      } catch {
         // Log file might not exist or be readable
       }
     }

--- a/apps/api/routes/assets.js
+++ b/apps/api/routes/assets.js
@@ -2,10 +2,7 @@ import express from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
-import { fileURLToPath } from 'url';
 import db from '../db.js';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const router = express.Router();
 
 // Create uploads directory if it doesn't exist

--- a/apps/api/routes/configuration.js
+++ b/apps/api/routes/configuration.js
@@ -4,7 +4,7 @@ import express from 'express';
 import ConfigurationManager from '../config/app-settings.js';
 import { authenticateJWT } from '../middleware/auth.js';
 import { createRateLimit } from '../middleware/rateLimiter.js';
-import { body, query, validationResult } from 'express-validator';
+import { body, validationResult } from 'express-validator';
 import { logger } from '../logger.js';
 
 const router = express.Router();

--- a/apps/api/routes/directory.js
+++ b/apps/api/routes/directory.js
@@ -32,7 +32,7 @@ router.get('/config', async (req, res) => {
   try {
     const cfg = await getConfig();
     res.json(cfg);
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Database error', errorCode: 'DB_ERROR' });
   }
 });
@@ -78,7 +78,7 @@ router.get('/search', async (req, res) => {
     const q = (req.query.q || '').toLowerCase();
     const results = await searchDirectory(q);
     res.json(results);
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Directory search failed', errorCode: 'DIRECTORY_SEARCH_ERROR' });
   }
 });
@@ -148,7 +148,7 @@ router.post('/user', async (req, res) => {
   try {
     const id = await createUser(name, email);
     res.json({ id, name, email });
-  } catch (err) {
+  } catch {
     res.status(500).json({ error: 'Failed to create user', errorCode: 'CREATE_USER_ERROR' });
   }
 });

--- a/apps/core/nova-core/src/App.tsx
+++ b/apps/core/nova-core/src/App.tsx
@@ -75,7 +75,7 @@ const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) =
         try {
           const user = await api.me(token);
           login(token, user);
-        } catch (error) {
+        } catch {
           localStorage.removeItem('auth_token');
         }
       }

--- a/apps/core/nova-core/src/components/ui/Grid.tsx
+++ b/apps/core/nova-core/src/components/ui/Grid.tsx
@@ -2,12 +2,9 @@ import React from 'react';
 export interface GridProps extends React.HTMLAttributes<HTMLDivElement> {
   container?: boolean;
   item?: boolean;
-  xs?: number;
-  sm?: number;
-  md?: number;
   spacing?: number;
 }
-export const Grid: React.FC<GridProps> = ({ container, item, xs, sm, md, spacing, className, style, children, ...props }) => {
+export const Grid: React.FC<GridProps> = ({ container, item, spacing, className, style, children, ...props }) => {
   const classes = [className, container ? 'grid-container' : '', item ? 'grid-item' : '']
     .filter(Boolean).join(' ');
   const gridStyle = {

--- a/apps/core/nova-core/src/pages/EmailAccountsPage.tsx
+++ b/apps/core/nova-core/src/pages/EmailAccountsPage.tsx
@@ -17,7 +17,6 @@ interface AccountForm {
 
 export const EmailAccountsPage: React.FC = () => {
   const [accounts, setAccounts] = useState<EmailAccount[]>([]);
-  const [loading, setLoading] = useState(true);
   const [showModal, setShowModal] = useState(false);
   const [editing, setEditing] = useState<EmailAccount | null>(null);
   const { addToast } = useToastStore();
@@ -36,12 +35,11 @@ export const EmailAccountsPage: React.FC = () => {
 
   const load = async () => {
     try {
-      setLoading(true);
       const data = await api.getEmailAccounts();
       setAccounts(data);
-    } catch (err) {
+    } catch {
       addToast({ type: 'error', title: 'Error', description: 'Failed to load accounts' });
-    } finally { setLoading(false); }
+    }
   };
 
   const save = async () => {
@@ -55,7 +53,7 @@ export const EmailAccountsPage: React.FC = () => {
       setEditing(null);
       await load();
       addToast({ type: 'success', title: 'Saved', description: 'Email account saved' });
-    } catch (err) {
+    } catch {
       addToast({ type: 'error', title: 'Error', description: 'Failed to save account' });
     }
   };

--- a/apps/core/nova-core/src/pages/KiosksPage.tsx
+++ b/apps/core/nova-core/src/pages/KiosksPage.tsx
@@ -179,7 +179,7 @@ export const KiosksPage: React.FC = () => {
         title: 'Copied',
         description: 'Activation code copied to clipboard',
       });
-    } catch (error) {
+    } catch {
       addToast({
         type: 'error',
         title: 'Error',

--- a/apps/core/nova-core/src/pages/SAMLConfigurationPage.tsx
+++ b/apps/core/nova-core/src/pages/SAMLConfigurationPage.tsx
@@ -237,7 +237,7 @@ export const SAMLConfigurationPage: React.FC = () => {
         title: 'Success',
         description: 'IdP metadata parsed successfully'
       });
-    } catch (error) {
+    } catch {
       addToast({
         type: 'error',
         title: 'Error',

--- a/apps/core/nova-core/src/pages/SCIMProvisioningMonitor.tsx
+++ b/apps/core/nova-core/src/pages/SCIMProvisioningMonitor.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { api } from '@/lib/api';
 import {
   Button,
   Card,
@@ -187,7 +188,7 @@ export default function SCIMProvisioningMonitor() {
   // Load SCIM Configuration
   const loadSCIMConfig = useCallback(async () => {
     try {
-      const response = await apiClient.get<SCIMConfig>('/api/scim-config');
+      const response = await api.get<SCIMConfig>('/api/scim-config');
       setSCIMConfig(response.data);
     } catch (err) {
       console.error('Failed to load SCIM config:', err);
@@ -201,7 +202,7 @@ export default function SCIMProvisioningMonitor() {
     
     try {
       setRefreshing(true);
-      const response = await apiClient.get<{ Resources: SCIMUser[] }>('/scim/v2/Users');
+      const response = await api.get<{ Resources: SCIMUser[] }>('/scim/v2/Users');
       if (response.data && response.data.Resources) {
         setSCIMUsers(response.data.Resources);
       }
@@ -218,7 +219,7 @@ export default function SCIMProvisioningMonitor() {
     if (!scimConfig.enabled || !scimConfig.groupSyncEnabled) return;
     
     try {
-      const response = await apiClient.get<{ Resources: SCIMGroup[] }>('/scim/v2/Groups');
+      const response = await api.get<{ Resources: SCIMGroup[] }>('/scim/v2/Groups');
       if (response.data && response.data.Resources) {
         setSCIMGroups(response.data.Resources);
       }

--- a/apps/core/nova-core/src/pages/UserManagementPage.tsx
+++ b/apps/core/nova-core/src/pages/UserManagementPage.tsx
@@ -13,7 +13,7 @@ import {
     UserPlusIcon,
     UsersIcon
 } from '@heroicons/react/24/outline';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface UserTableProps {
   users: User[];
@@ -354,6 +354,12 @@ export const UserManagementPage: React.FC = () => {
     toggleUserStatus
   } = useUsers(filters, currentPage, pageSize);
 
+  const isFormValid = (data: { name: string; email: string; password: string; roles: string[] }, requirePassword = false) => {
+    if (!data.name || !data.email) return false;
+    if (requirePassword && !data.password) return false;
+    return true;
+  };
+
   useEffect(() => {
     api.getRoles().then(setRoles).catch((e) => {
       console.error('Failed to load roles:', e);
@@ -413,7 +419,7 @@ export const UserManagementPage: React.FC = () => {
       email: formData.email,
       password: formData.password,
       roles: formData.roles,
-    } as CreateUserInput);
+    });
     if (newUser) {
       addToast({ type: 'success', title: 'User Created', description: 'User created successfully' });
       setShowCreateModal(false);

--- a/apps/core/nova-core/src/pages/VIPManagementPage.tsx
+++ b/apps/core/nova-core/src/pages/VIPManagementPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Button, Card, Input, Select } from '@/components/ui';
+import { Card, Select } from '@/components/ui';
 import { api } from '@/lib/api';
 import { useToastStore } from '@/stores/toast';
 import type { User } from '@/types';

--- a/apps/core/nova-core/src/pages/auth/LoginPage.tsx
+++ b/apps/core/nova-core/src/pages/auth/LoginPage.tsx
@@ -8,6 +8,11 @@ import { useApiHealth } from '@/hooks/useApiHealth';
 import { ServerConnectionModal } from '@/components/ServerConnectionModal';
 import { api } from '@/lib/api';
 
+interface Branding {
+  logo?: string | null;
+  themeColor?: string;
+}
+
 export const LoginPage: React.FC = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');


### PR DESCRIPTION
## Summary
- fix unused variables and const assignments in backup CLI
- clean up dashboard CLI unused imports and catch blocks
- prune unused imports and variables in API routes
- tighten nova-core app catch blocks
- remove unused props from Grid component
- fix LoginPage branding type
- add helper for UserManagementPage form validation
- adjust SCIM provisioning monitor to use api client
- remove unused code in EmailAccounts and Kiosks pages
- update VIPManagementPage imports

## Testing
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688c2f7f687c8333a8f34fafb4492044