### PR TITLE
Add meaningful tests for API, core, and comms

### DIFF
--- a/apps/api/test/utils.test.js
+++ b/apps/api/test/utils.test.js
@@ -1,0 +1,56 @@
+import { calculateVipWeight } from '../utils/utils.js';
+import { getEmailStrategy } from '../utils/serviceHelpers.js';
+
+describe('calculateVipWeight', () => {
+  test('returns 0 when not VIP', () => {
+    expect(calculateVipWeight(false)).toBe(0);
+  });
+
+  test('throws when vipLevel missing for VIP', () => {
+    expect(() => calculateVipWeight(true)).toThrow('vipLevel must be provided');
+  });
+
+  test('returns weight for levels', () => {
+    expect(calculateVipWeight(true, 'exec')).toBe(3);
+    expect(calculateVipWeight(true, 'gold')).toBe(2);
+    expect(calculateVipWeight(true, 'silver')).toBe(1);
+  });
+});
+
+describe('getEmailStrategy', () => {
+  const ORIGINAL_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env.HELPSCOUT_API_KEY;
+    delete process.env.HELPSCOUT_MAILBOX_ID;
+    delete process.env.HELPSCOUT_SMTP_FALLBACK;
+    delete process.env.M365_CLIENT_ID;
+    delete process.env.M365_CLIENT_SECRET;
+    delete process.env.M365_TENANT_ID;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('uses HelpScout when configured', () => {
+    process.env.HELPSCOUT_API_KEY = 'key';
+    process.env.HELPSCOUT_MAILBOX_ID = 'box';
+
+    const strategy = getEmailStrategy();
+    expect(strategy.sendViaHelpScout).toBe(true);
+    expect(strategy.sendViaSmtp).toBe(false);
+    expect(strategy.helpScout).toEqual({
+      apiKey: 'key',
+      mailboxId: 'box',
+      smtpFallback: false,
+    });
+  });
+
+  test('falls back to SMTP when nothing configured', () => {
+    const strategy = getEmailStrategy();
+    expect(strategy.sendViaSmtp).toBe(true);
+    expect(strategy.sendViaHelpScout).toBe(false);
+    expect(strategy.sendViaM365).toBe(false);
+  });
+});

--- a/apps/comms/nova-comms/test/environment.test.js
+++ b/apps/comms/nova-comms/test/environment.test.js
@@ -1,0 +1,32 @@
+import { validateEnv } from '../environment.js';
+
+describe('validateEnv', () => {
+  const ORIGINAL_ENV = process.env;
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+  afterEach(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  test('throws when required variables missing', () => {
+    delete process.env.SLACK_SIGNING_SECRET;
+    delete process.env.SLACK_BOT_TOKEN;
+    delete process.env.API_URL;
+    delete process.env.JWT_SECRET;
+    expect(() => validateEnv()).toThrow(/Missing required environment variables/);
+  });
+
+  test('returns config when variables provided', () => {
+    process.env.SLACK_SIGNING_SECRET = 'sig';
+    process.env.SLACK_BOT_TOKEN = 'token';
+    process.env.API_URL = 'http://example.com';
+    process.env.JWT_SECRET = 'secret';
+    process.env.SLACK_PORT = '4000';
+    process.env.JWT_EXPIRES_IN = '2h';
+    process.env.VITE_ADMIN_URL = 'http://admin';
+
+    const config = validateEnv();
+    expect(config).toEqual({ port: 4000, jwtExpiresIn: '2h', adminUrl: 'http://admin' });
+  });
+});

--- a/apps/core/nova-core/package.json
+++ b/apps/core/nova-core/package.json
@@ -9,7 +9,7 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@headlessui/react": "^2.0.4",

--- a/apps/core/nova-core/src/utils.test.ts
+++ b/apps/core/nova-core/src/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { getUrgencyColor, validateEmail, generateRandomString } from './lib/utils';
+
+describe('getUrgencyColor', () => {
+  it('returns class names based on urgency', () => {
+    expect(getUrgencyColor('urgent')).toBe('bg-red-100 text-red-800 border-red-200');
+    expect(getUrgencyColor('high')).toBe('bg-orange-100 text-orange-800 border-orange-200');
+    expect(getUrgencyColor('medium')).toBe('bg-yellow-100 text-yellow-800 border-yellow-200');
+    expect(getUrgencyColor('low')).toBe('bg-green-100 text-green-800 border-green-200');
+    expect(getUrgencyColor('unknown')).toBe('bg-gray-100 text-gray-800 border-gray-200');
+  });
+});
+
+describe('validateEmail', () => {
+  it('validates proper email formats', () => {
+    expect(validateEmail('test@example.com')).toBe(true);
+    expect(validateEmail('bad-email')).toBe(false);
+  });
+});
+
+describe('generateRandomString', () => {
+  it('returns a string of the requested length', () => {
+    const str = generateRandomString(8);
+    expect(str).toHaveLength(8);
+    expect(/^[A-Za-z0-9]+$/.test(str)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace placeholder tests with real unit tests
- cover API helpers like `calculateVipWeight` and `getEmailStrategy`
- check Slack environment validation logic
- test core admin utility functions

## Testing
- `pnpm --filter nova-universe-api test`
- `pnpm --filter nova-core-admin test`
- `pnpm --filter cueit-slack test`


------
https://chatgpt.com/codex/tasks/task_e_688c3adfa7988333a3f5281b4eea267c