### PR TITLE
Fix installer scripts for start-all.sh path

### DIFF
--- a/scripts/make-installer.sh
+++ b/scripts/make-installer.sh
@@ -9,7 +9,7 @@ VERSION="${1:-1.0.0}"
 RES_DIR="./dist/resources"
 mkdir -p "$RES_DIR/installers"
 cp -R nova-api nova-core nova-comms design "$RES_DIR/"
-cp installers/start-all.sh "$RES_DIR/installers/"
+cp scripts/start-all.sh "$RES_DIR/installers/"
 # copy .env.example to .env so the launcher does not need to write inside
 # the application bundle on first run
 for pkg in nova-api nova-core nova-comms; do

--- a/scripts/make-linux-installer.sh
+++ b/scripts/make-linux-installer.sh
@@ -11,7 +11,7 @@ npm --prefix nova-core run build
 RES_DIR="./dist/resources"
 mkdir -p "$RES_DIR/installers"
 cp -R nova-api nova-core nova-comms design "$RES_DIR/"
-cp installers/start-all.sh "$RES_DIR/installers/"
+cp scripts/start-all.sh "$RES_DIR/installers/"
 for pkg in nova-api nova-core nova-comms; do
   cp "$pkg/.env.example" "$RES_DIR/$pkg/.env"
 done

--- a/scripts/make-windows-installer.ps1
+++ b/scripts/make-windows-installer.ps1
@@ -12,7 +12,7 @@ $RES_DIR = Join-Path (Get-Location) 'dist\resources'
 if (-not (Test-Path $RES_DIR)) { New-Item -ItemType Directory -Path $RES_DIR | Out-Null }
 
 Copy-Item nova-api, nova-core, nova-comms, design -Destination $RES_DIR -Recurse -Force
-Copy-Item installers\start-all.sh $RES_DIR\installers -Force
+Copy-Item scripts\start-all.sh $RES_DIR\installers -Force
 
 foreach ($pkg in 'nova-api','nova-core','nova-comms') {
   Copy-Item (Join-Path $pkg '.env.example') (Join-Path $RES_DIR $pkg '.env') -Force


### PR DESCRIPTION
## Summary
- ensure installer scripts package launcher from `scripts/start-all.sh`

## Testing
- `npm test` *(fails: Validation Error extensionsToTreatAsEsm)*

------
https://chatgpt.com/codex/tasks/task_e_688c41cf78188333b895b56416181f6f