### PR TITLE
Clean up README quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<p align="center"><img src="nova-core/public/logo.png" alt="Nova Universe logo" width="50"/></p>
 # Nova Universe
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/itristenx/nova-universe/ci.yml?branch=main)](https://github.com/itristenx/nova-universe/actions)
@@ -39,7 +40,7 @@ The `design/theme.js` file defines shared colors, fonts and spacing. Frontends i
 
 ---
 
-## Getting Started
+## Quick Start
 
 ### Requirements
 - [Node.js](https://nodejs.org/) 18 or higher
@@ -47,7 +48,7 @@ The `design/theme.js` file defines shared colors, fonts and spacing. Frontends i
 - sqlite3
 - [Mailpit](https://github.com/axllent/mailpit) (SMTP testing server)
 
-### Quick Start
+### Steps
 
 ```bash
 git clone https://github.com/itristenx/nova-universe.git
@@ -101,27 +102,6 @@ This project is licensed under the [MIT License](LICENSE).
 
 For questions, suggestions, or support, please use [GitHub Discussions](https://github.com/itristenx/nova-universe/discussions) or open an issue.
 
----
-
-## Requirements
-- [Node.js](https://nodejs.org/) 18 or higher
-- npm
-- sqlite3
-- [Mailpit](https://github.com/axllent/mailpit) (SMTP testing server)
-
-## Quick Start
-
-```bash
-git clone https://github.com/itristenx/nova-universe.git
-cd nova-universe
-./scripts/setup.sh
-./scripts/init-env.sh
-./scripts/start-all.sh
-```
-
-Open http://localhost:5173 to access the admin interface.
-
-**Default login:** admin@example.com / admin
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="nova-core/public/logo.png" alt="Nova Universe logo" width="50"/></p>
+<p align="center"><img src="assets/logo.png" alt="Nova Universe logo" width="50"/></p>
 # Nova Universe
 
 [![Build Status](https://img.shields.io/github/actions/workflow/status/itristenx/nova-universe/ci.yml?branch=main)](https://github.com/itristenx/nova-universe/actions)


### PR DESCRIPTION
## Summary
- add 50px logo image at the top of README
- combine requirements and quick start into a single section
- drop duplicate quick start section

## Testing
- `npm test` *(fails: extensionsToTreatAsEsm validation error)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688c43a64d248333ba1d71ce33cf41c9