### PR TITLE
chore(prisma): split schema files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules node --test test/*.test.js",
     "type-check": "tsc --noEmit",
-    "lint": "eslint . --config ./tools/config/eslint.config.js"
+    "lint": "eslint . --config ./tools/config/eslint.config.js",
+    "prisma:generate:core": "prisma generate --schema prisma/core/schema.prisma",
+    "prisma:generate:auth": "prisma generate --schema prisma/auth/schema.prisma",
+    "prisma:generate:audit": "prisma generate --schema prisma/audit/schema.prisma"
   },
   "devDependencies": {
     "esmock": "^2.7.1",

--- a/prisma/audit/schema.prisma
+++ b/prisma/audit/schema.prisma
@@ -1,0 +1,10 @@
+datasource audit_db {
+  provider = "mongodb"
+  url      = env("AUDIT_DATABASE_URL")
+}
+
+generator auditClient {
+  provider   = "prisma-client-js"
+  datasource = "audit_db"
+  output     = "../generated/audit"
+}

--- a/prisma/auth/schema.prisma
+++ b/prisma/auth/schema.prisma
@@ -1,0 +1,10 @@
+datasource auth_db {
+  provider = "postgresql"
+  url      = env("AUTH_DATABASE_URL")
+}
+
+generator authClient {
+  provider   = "prisma-client-js"
+  datasource = "auth_db"
+  output     = "../generated/auth"
+}

--- a/prisma/core/schema.prisma
+++ b/prisma/core/schema.prisma
@@ -3,32 +3,10 @@ datasource core_db {
   url      = env("CORE_DATABASE_URL")
 }
 
-datasource auth_db {
-  provider = "postgresql"
-  url      = env("AUTH_DATABASE_URL")
-}
-
-datasource audit_db {
-  provider = "mongodb"
-  url      = env("AUDIT_DATABASE_URL")
-}
-
 generator coreClient {
-  provider = "prisma-client-js"
+  provider   = "prisma-client-js"
   datasource = "core_db"
-  output   = "./generated/core"
-}
-
-generator authClient {
-  provider = "prisma-client-js"
-  datasource = "auth_db"
-  output   = "./generated/auth"
-}
-
-generator auditClient {
-  provider = "prisma-client-js"
-  datasource = "audit_db"
-  output   = "./generated/audit"
+  output     = "../generated/core"
 }
 
 model User {


### PR DESCRIPTION
## Summary
- split prisma schema into core, auth, and audit versions
- add scripts to generate clients for each schema

## Testing
- `pnpm lint` *(fails: RequestCatalogItem is not defined)*
- `pnpm type-check` *(fails: tsc --noEmit)*
- `pnpm test`
- `npx prisma validate --schema prisma/core/schema.prisma` *(fails: missing opposite relation field for RITM, VipProxy, VipSlaHistory)*
- `npx prisma validate --schema prisma/auth/schema.prisma` *(fails: Environment variable not found: AUTH_DATABASE_URL)*
- `npx prisma validate --schema prisma/audit/schema.prisma` *(fails: Environment variable not found: AUDIT_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_688fdf12568c8333995987f4007f4867