### PR TITLE
refactor: use generated prisma clients

### DIFF
--- a/apps/api/db.js
+++ b/apps/api/db.js
@@ -6,7 +6,7 @@ import bcrypt from 'bcryptjs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { v4 as uuidv4 } from 'uuid';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../../prisma/generated/core';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/apps/api/routes/mailroom.js
+++ b/apps/api/routes/mailroom.js
@@ -1,7 +1,7 @@
 // Nova Mailroom API routes
 const express = require('express');
 const router = express.Router();
-const { PrismaClient } = require('@prisma/client');
+const { PrismaClient } = require('../../../prisma/generated/core');
 const prisma = new PrismaClient();
 const { requireRole } = require('../middleware/rbac');
 const { logAudit } = require('../middleware/audit');

--- a/src/lib/db/postgres.ts
+++ b/src/lib/db/postgres.ts
@@ -1,6 +1,6 @@
 // src/lib/db/postgres.ts
 // Prisma client for PostgreSQL core data
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '../../../prisma/generated/core';
 import { logger } from '../../../apps/api/logger.js';
 
 declare global {


### PR DESCRIPTION
## Summary
- use generated Prisma Client for core DB access in shared postgres utility
- switch API database module to generated Prisma Client
- update mailroom routes to use generated Prisma Client

## Testing
- `npm run prisma:generate:core` *(fails: Error validating field `ticket` in model `RITM` ...)*
- `npm run prisma:generate:auth`
- `npm run prisma:generate:audit`
- `npm test`
- `npm run lint` *(fails: RequestCatalogItem is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6890e07d64008333b1a3b67047272840