### PR TITLE
Establish CMDB standards and build

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -26,6 +26,7 @@ import statusSummaryRouter from './routes/status.js';
 import announcementsRouter from './routes/announcements.js';
 import cosmoRouter from './routes/cosmo.js';
 import beaconRouter from './routes/beacon.js';
+import cmdbRouter from './routes/cmdb.js';
 // Nova module routes
 import { Strategy as SamlStrategy } from '@node-saml/passport-saml';
 import {
@@ -1702,6 +1703,7 @@ app.use('/api/v1/directory', directoryRouter);
 app.use('/api/v1/roles', rolesRouter);
 app.use('/api/v1/assets', assetsRouter);
 app.use('/api/v1/inventory', inventoryRouter);
+app.use('/api/v1/cmdb', cmdbRouter);
 app.use('/api/v1/integrations', integrationsRouter);
 app.use('/api/catalog-items', catalogItemsRouter);
 app.use('/api/v1/search', searchRouter);

--- a/apps/api/routes/cmdb.js
+++ b/apps/api/routes/cmdb.js
@@ -1,0 +1,216 @@
+import express from 'express';
+import db from '../db.js';
+import { authenticateJWT } from '../middleware/auth.js';
+
+const router = express.Router();
+
+// Utilities
+function toInt(val, def = 10) {
+  const n = parseInt(String(val || ''));
+  return Number.isNaN(n) ? def : n;
+}
+
+// Classes
+router.get('/classes', authenticateJWT, async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM ci_classes ORDER BY name');
+    res.json({ success: true, classes: rows });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to list classes' });
+  }
+});
+
+router.post('/classes', authenticateJWT, async (req, res) => {
+  try {
+    const { name, label, description, parent_id } = req.body || {};
+    if (!name) return res.status(400).json({ success: false, error: 'name required' });
+    const { rows } = await db.query(
+      `INSERT INTO ci_classes (name, label, description, parent_id) VALUES ($1,$2,$3,$4) RETURNING *`,
+      [name, label || null, description || null, parent_id || null]
+    );
+    res.json({ success: true, class: rows[0] });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to create class' });
+  }
+});
+
+// Items
+router.get('/items', authenticateJWT, async (req, res) => {
+  try {
+    const { q, classId, limit, offset } = req.query;
+    const where = [];
+    const params = [];
+    if (q) {
+      params.push(`%${q}%`);
+      where.push(`(name ILIKE $${params.length})`);
+    }
+    if (classId) {
+      params.push(classId);
+      where.push(`class_id = $${params.length}`);
+    }
+    const lim = toInt(limit, 50);
+    const off = toInt(offset, 0);
+    params.push(lim);
+    params.push(off);
+
+    const sql = `SELECT * FROM ci_items ${where.length ? 'WHERE ' + where.join(' AND ') : ''} ORDER BY id DESC LIMIT $${params.length - 1} OFFSET $${params.length}`;
+    const { rows } = await db.query(sql, params);
+    res.json({ success: true, items: rows });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to list items' });
+  }
+});
+
+router.get('/items/:id', authenticateJWT, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const { rows } = await db.query('SELECT * FROM ci_items WHERE id=$1', [id]);
+    if (!rows[0]) return res.status(404).json({ success: false, error: 'Not found' });
+    // fetch identifiers and relationships
+    const [idents, relsOut, relsIn] = await Promise.all([
+      db.query('SELECT * FROM ci_identifiers WHERE item_id=$1 ORDER BY namespace, name', [id]),
+      db.query(`SELECT r.*, t.name as type_name, t.forward_label FROM ci_relationships r JOIN ci_relationship_types t ON r.type_id=t.id WHERE source_item_id=$1`, [id]),
+      db.query(`SELECT r.*, t.name as type_name, t.reverse_label FROM ci_relationships r JOIN ci_relationship_types t ON r.type_id=t.id WHERE target_item_id=$1`, [id]),
+    ]);
+    res.json({ success: true, item: rows[0], identifiers: idents.rows, relationships: { out: relsOut.rows, in: relsIn.rows } });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to get item' });
+  }
+});
+
+router.post('/items', authenticateJWT, async (req, res) => {
+  try {
+    const { class_id, name, status, environment, owner_user_id, owner_group, criticality, attributes, identifiers } = req.body || {};
+    if (!class_id || !name) return res.status(400).json({ success: false, error: 'class_id and name required' });
+    const { rows } = await db.query(
+      `INSERT INTO ci_items (class_id, name, status, environment, owner_user_id, owner_group, criticality, attributes) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING *`,
+      [class_id, name, status || 'active', environment || null, owner_user_id || null, owner_group || null, criticality || null, attributes || {}]
+    );
+    const item = rows[0];
+    if (Array.isArray(identifiers) && identifiers.length) {
+      for (const iden of identifiers) {
+        if (!iden) continue;
+        await db.query(
+          `INSERT INTO ci_identifiers (item_id, namespace, name, value) VALUES ($1,$2,$3,$4) ON CONFLICT (namespace,name,value) DO NOTHING`,
+          [item.id, iden.namespace || 'default', iden.name || 'name', iden.value]
+        );
+      }
+    }
+    await db.query('INSERT INTO ci_audit (item_id, action, diff, user_id) VALUES ($1,$2,$3,$4)', [item.id, 'create', req.body || {}, req.user?.id || null]);
+    res.json({ success: true, item });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to create item' });
+  }
+});
+
+router.put('/items/:id', authenticateJWT, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const fields = ['class_id','name','status','environment','owner_user_id','owner_group','criticality','attributes'];
+    const set = [];
+    const params = [];
+    fields.forEach((f) => {
+      if (req.body[f] !== undefined) {
+        params.push(req.body[f]);
+        set.push(`${f} = $${params.length}`);
+      }
+    });
+    if (set.length === 0) return res.json({ success: true, item: (await db.query('SELECT * FROM ci_items WHERE id=$1',[id])).rows[0] });
+    params.push(id);
+    const { rows } = await db.query(`UPDATE ci_items SET ${set.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id=$${params.length} RETURNING *`, params);
+    await db.query('INSERT INTO ci_audit (item_id, action, diff, user_id) VALUES ($1,$2,$3,$4)', [id, 'update', req.body || {}, req.user?.id || null]);
+    res.json({ success: true, item: rows[0] });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to update item' });
+  }
+});
+
+router.delete('/items/:id', authenticateJWT, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    await db.query('INSERT INTO ci_audit (item_id, action, user_id) VALUES ($1,$2,$3)', [id, 'delete', req.user?.id || null]);
+    await db.query('DELETE FROM ci_items WHERE id=$1', [id]);
+    res.json({ success: true });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to delete item' });
+  }
+});
+
+// Relationship types
+router.get('/relationship-types', authenticateJWT, async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT * FROM ci_relationship_types ORDER BY name');
+    res.json({ success: true, types: rows });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to list relationship types' });
+  }
+});
+
+router.post('/relationship-types', authenticateJWT, async (req, res) => {
+  try {
+    const { name, forward_label, reverse_label, description } = req.body || {};
+    if (!name || !forward_label || !reverse_label) return res.status(400).json({ success: false, error: 'name, forward_label, reverse_label required' });
+    const { rows } = await db.query(
+      `INSERT INTO ci_relationship_types (name, forward_label, reverse_label, description) VALUES ($1,$2,$3,$4) RETURNING *`,
+      [name, forward_label, reverse_label, description || null]
+    );
+    res.json({ success: true, type: rows[0] });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to create relationship type' });
+  }
+});
+
+// Relationships
+router.post('/relationships', authenticateJWT, async (req, res) => {
+  try {
+    const { type_id, source_item_id, target_item_id, properties } = req.body || {};
+    if (!type_id || !source_item_id || !target_item_id) return res.status(400).json({ success: false, error: 'type_id, source_item_id, target_item_id required' });
+    const { rows } = await db.query(
+      `INSERT INTO ci_relationships (type_id, source_item_id, target_item_id, properties, created_by) VALUES ($1,$2,$3,$4,$5) RETURNING *`,
+      [type_id, source_item_id, target_item_id, properties || {}, req.user?.id || null]
+    );
+    res.json({ success: true, relationship: rows[0] });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to create relationship' });
+  }
+});
+
+router.get('/items/:id/relationships', authenticateJWT, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id);
+    const { rows } = await db.query(
+      `SELECT r.*, t.name as type_name, t.forward_label, t.reverse_label,
+              s.name as source_name, d.name as target_name
+       FROM ci_relationships r
+       JOIN ci_relationship_types t ON r.type_id=t.id
+       JOIN ci_items s ON r.source_item_id=s.id
+       JOIN ci_items d ON r.target_item_id=d.id
+       WHERE r.source_item_id=$1 OR r.target_item_id=$1`,
+      [id]
+    );
+    res.json({ success: true, relationships: rows });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Failed to list relationships' });
+  }
+});
+
+// Simple search
+router.get('/search', authenticateJWT, async (req, res) => {
+  try {
+    const { q } = req.query;
+    if (!q || String(q).length < 2) return res.status(400).json({ success: false, error: 'q too short' });
+    const like = `%${q}%`;
+    const { rows } = await db.query(
+      `SELECT i.*, c.name AS class_name
+       FROM ci_items i JOIN ci_classes c ON i.class_id=c.id
+       WHERE i.name ILIKE $1 OR CAST(i.attributes AS TEXT) ILIKE $1
+       ORDER BY i.updated_at DESC LIMIT 50`,
+      [like]
+    );
+    res.json({ success: true, results: rows });
+  } catch (e) {
+    res.status(500).json({ success: false, error: 'Search failed' });
+  }
+});
+
+export default router;

--- a/apps/core/nova-core/src/App.tsx
+++ b/apps/core/nova-core/src/App.tsx
@@ -33,6 +33,7 @@ const KnowledgeListPage = React.lazy(() => import('@/pages/knowledge/KnowledgeLi
 const KnowledgeDetailPage = React.lazy(() => import('@/pages/knowledge/KnowledgeDetailPage').then(m => ({ default: m.default }))); 
 const KnowledgeEditPage = React.lazy(() => import('@/pages/knowledge/KnowledgeEditPage').then(m => ({ default: m.default })));
 const APIDocumentationPage = React.lazy(() => import('@/pages/APIDocumentationPage').then(m => ({ default: m.default })));
+const CMDBPage = React.lazy(() => import('@/pages/CMDBPage').then(m => ({ default: m.default })));
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -216,6 +217,14 @@ const AppRoutes: React.FC = () => {
           element={
             <React.Suspense fallback={<div>Loading...</div>}>
               <CatalogItemsPage />
+            </React.Suspense>
+          }
+        />
+        <Route
+          path="cmdb"
+          element={
+            <React.Suspense fallback={<div>Loading...</div>}>
+              <CMDBPage />
             </React.Suspense>
           }
         />

--- a/apps/core/nova-core/src/components/layout/Sidebar.tsx
+++ b/apps/core/nova-core/src/components/layout/Sidebar.tsx
@@ -29,6 +29,7 @@ const navigation = [
   { name: 'Email Accounts', href: '/email-accounts', icon: Cog6ToothIcon },
   { name: 'Modules', href: '/modules', icon: Cog6ToothIcon },
   { name: 'Settings', href: '/settings', icon: CogIcon },
+  { name: 'CMDB', href: '/cmdb', icon: ComputerDesktopIcon },
 ];
 
 interface SidebarProps {

--- a/apps/core/nova-core/src/pages/CMDBPage.tsx
+++ b/apps/core/nova-core/src/pages/CMDBPage.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
+const fetchJson = async (url: string, init?: RequestInit) => {
+  const res = await fetch(url, init);
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+};
+
+interface CiClass {
+  id: number;
+  name: string;
+  label?: string;
+  description?: string;
+  parent_id?: number | null;
+}
+
+interface CiItem {
+  id: number;
+  class_id: number;
+  name: string;
+  status?: string;
+  environment?: string;
+  owner_user_id?: string;
+  owner_group?: string;
+  criticality?: number;
+  attributes?: Record<string, unknown>;
+}
+
+const CMDBPage: React.FC = () => {
+  const [classes, setClasses] = useState<CiClass[]>([]);
+  const [items, setItems] = useState<CiItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [selectedClass, setSelectedClass] = useState<string>('');
+
+  const load = async () => {
+    try {
+      setLoading(true);
+      const [c, i] = await Promise.all([
+        fetchJson('/api/v1/cmdb/classes'),
+        fetchJson('/api/v1/cmdb/items'),
+      ]);
+      setClasses(c.classes || []);
+      setItems(i.items || []);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load CMDB');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const filtered = useMemo(() => {
+    return items.filter((it) => {
+      if (selectedClass) {
+        const c = parseInt(selectedClass);
+        if (it.class_id !== c) return false;
+      }
+      if (query) {
+        const q = query.toLowerCase();
+        return it.name.toLowerCase().includes(q) || JSON.stringify(it.attributes || {}).toLowerCase().includes(q);
+      }
+      return true;
+    });
+  }, [items, query, selectedClass]);
+
+  const createQuick = async () => {
+    const name = prompt('CI name');
+    if (!name) return;
+    const classId = parseInt(prompt('Class ID (numeric)') || '');
+    if (!classId) return;
+    await fetchJson('/api/v1/cmdb/items', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ class_id: classId, name }),
+    });
+    await load();
+  };
+
+  if (loading) return <div className="p-4">Loading CMDB...</div>;
+  if (error) return <div className="p-4 text-red-600">{error}</div>;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-semibold">CMDB</h1>
+
+      <div className="flex gap-2 items-center">
+        <select className="border rounded px-2 py-1" value={selectedClass} onChange={(e) => setSelectedClass(e.target.value)}>
+          <option value="">All classes</option>
+          {classes.map((c) => (
+            <option key={c.id} value={c.id.toString()}>
+              {c.label || c.name} (#{c.id})
+            </option>
+          ))}
+        </select>
+        <input className="border rounded px-2 py-1 flex-1" placeholder="Search name or attributes..." value={query} onChange={(e) => setQuery(e.target.value)} />
+        <button className="border rounded px-3 py-1" onClick={createQuick}>Quick add</button>
+      </div>
+
+      <div className="overflow-auto border rounded">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="bg-gray-50">
+              <th className="text-left p-2">ID</th>
+              <th className="text-left p-2">Class</th>
+              <th className="text-left p-2">Name</th>
+              <th className="text-left p-2">Status</th>
+              <th className="text-left p-2">Environment</th>
+              <th className="text-left p-2">Attributes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((it) => (
+              <tr key={it.id} className="border-t">
+                <td className="p-2">{it.id}</td>
+                <td className="p-2">{it.class_id}</td>
+                <td className="p-2">{it.name}</td>
+                <td className="p-2">{it.status || 'active'}</td>
+                <td className="p-2">{it.environment || '-'}</td>
+                <td className="p-2 font-mono text-xs">{JSON.stringify(it.attributes || {})}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="text-xs text-gray-500">Tip: use API `/api/v1/cmdb/relationship-types` and `/api/v1/cmdb/relationships` to model dependencies</div>
+    </div>
+  );
+};
+
+export default CMDBPage;


### PR DESCRIPTION
# Pull Request

## Description

This PR establishes a foundational Configuration Management Database (CMDB) module, designed to align with industry standards like ITIL and ServiceNow's CSDM. The primary motivation is to provide a structured system for managing configuration items (CIs) and their interdependencies, crucial for enhanced IT service management and impact analysis.

Key changes include:
-   **Backend (API):** Introduction of new database schemas for CIs, relationships, and audit trails, along with a comprehensive REST API (`/api/v1/cmdb`) for managing CMDB data.
-   **Frontend (Core):** A new administrative UI page (`/cmdb`) in the Core application for basic CMDB item listing, filtering, and quick creation, integrated into the navigation.

Fixes # (No specific issue number provided, addresses the task of creating a CMDB like ServiceNow)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (describe):

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)
N/A

## Additional context
This initial implementation provides the core data model and API endpoints for CMDB functionality, along with a basic administrative interface in the Core application. Further enhancements would include more advanced UI features, reconciliation logic, and integrations.

---
Thank you for your contribution! Please read the [contributing guidelines](CONTRIBUTING.md) and [code of conduct](CODE_OF_CONDUCT.md) before submitting.

---
<a href="https://cursor.com/background-agent?bcId=bc-14acfc58-ab75-4a19-a5de-788e2cc4621e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14acfc58-ab75-4a19-a5de-788e2cc4621e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

