### PR TITLE
fix: align service status and login i18n keys

### DIFF
--- a/apps/unified/src/i18n/locales/ar.json
+++ b/apps/unified/src/i18n/locales/ar.json
@@ -18,6 +18,8 @@
       "enterVerificationCode": "أدخل رمز التحقق",
       "workEmail": "البريد الإلكتروني للعمل",
       "emailPlaceholder": "أدخل عنوان بريدك الإلكتروني للعمل",
+      "password": "كلمة المرور",
+      "passwordPlaceholder": "أدخل كلمة المرور",
       "discovering": "اكتشاف المؤسسة...",
       "findOrganizationHelp": "أدخل بريدك الإلكتروني للعمل للعثور على مؤسستك",
       "organizationFound": "تم العثور على المؤسسة: {{organization}}",
@@ -29,6 +31,7 @@
       "forgotPassword": "نسيت كلمة المرور؟",
       "signIn": "تسجيل الدخول",
       "signInWith": "تسجيل الدخول باستخدام {{provider}}",
+      "orContinueWithPassword": "أو المتابعة باستخدام كلمة المرور",
       "mfaRequired": "مطلوب المصادقة الثنائية لهذا الحساب",
       "poweredBy": "مدعوم من",
       "helixBrand": "Nova Helix",
@@ -607,9 +610,12 @@
     "status": {
       "operational": "تشغيلي",
       "degraded": "متدهور",
-      "partialOutage": "انقطاع جزئي",
-      "majorOutage": "انقطاع كبير",
-      "underMaintenance": "تحت الصيانة"
+      "partial_outage": "انقطاع جزئي",
+      "major_outage": "انقطاع كبير",
+      "under_maintenance": "تحت الصيانة",
+      "in_progress": "قيد التنفيذ",
+      "completed": "مكتمل",
+      "scheduled": "مجدول"
     },
     "severity": {
       "low": "منخفض",

--- a/apps/unified/src/i18n/locales/en.json
+++ b/apps/unified/src/i18n/locales/en.json
@@ -158,6 +158,7 @@
       "enterVerificationCode": "Enter verification code",
       "workEmail": "Work Email",
       "emailPlaceholder": "Enter your work email address",
+      "password": "Password",
       "passwordPlaceholder": "Enter your password",
       "discovering": "Discovering organization...",
       "findOrganizationHelp": "Enter your work email to find your organization",
@@ -170,6 +171,7 @@
       "forgotPassword": "Forgot your password?",
       "signIn": "Sign In",
       "signInWith": "Sign in with {{provider}}",
+      "orContinueWithPassword": "Or continue with password",
       "mfaRequired": "Two-factor authentication is required for this account",
       "poweredBy": "Powered by",
       "helixBrand": "Nova Helix",
@@ -997,9 +999,12 @@
     "status": {
       "operational": "Operational",
       "degraded": "Degraded",
-      "partialOutage": "Partial Outage",
-      "majorOutage": "Major Outage",
-      "underMaintenance": "Under Maintenance"
+      "partial_outage": "Partial Outage",
+      "major_outage": "Major Outage",
+      "under_maintenance": "Under Maintenance",
+      "in_progress": "In Progress",
+      "completed": "Completed",
+      "scheduled": "Scheduled"
     },
     "severity": {
       "low": "Low",

--- a/apps/unified/src/i18n/locales/es.json
+++ b/apps/unified/src/i18n/locales/es.json
@@ -50,6 +50,7 @@
       "enterVerificationCode": "Ingresa el código de verificación",
       "workEmail": "Email de Trabajo",
       "emailPlaceholder": "Ingresa tu dirección de email de trabajo",
+      "password": "Contraseña",
       "passwordPlaceholder": "Ingresa tu contraseña",
       "discovering": "Descubriendo organización...",
       "findOrganizationHelp": "Ingresa tu email de trabajo para encontrar tu organización",
@@ -62,6 +63,7 @@
       "forgotPassword": "¿Olvidaste tu contraseña?",
       "signIn": "Iniciar Sesión",
       "signInWith": "Iniciar sesión con {{provider}}",
+      "orContinueWithPassword": "o continuar con contraseña",
       "mfaRequired": "Se requiere autenticación de dos factores para esta cuenta",
       "poweredBy": "Desarrollado por",
       "helixBrand": "Nova Helix",
@@ -723,9 +725,12 @@
     "status": {
       "operational": "Operativo",
       "degraded": "Degradado",
-      "partialOutage": "Interrupción Parcial",
-      "majorOutage": "Interrupción Mayor",
-      "underMaintenance": "En Mantenimiento"
+      "partial_outage": "Interrupción Parcial",
+      "major_outage": "Interrupción Mayor",
+      "under_maintenance": "En Mantenimiento",
+      "in_progress": "En Progreso",
+      "completed": "Completado",
+      "scheduled": "Programado"
     },
     "severity": {
       "low": "Bajo",

--- a/apps/unified/src/i18n/locales/fr.json
+++ b/apps/unified/src/i18n/locales/fr.json
@@ -18,6 +18,8 @@
       "enterVerificationCode": "Entrez le code de vérification",
       "workEmail": "Email Professionnel",
       "emailPlaceholder": "Entrez votre adresse email professionnelle",
+      "password": "Mot de passe",
+      "passwordPlaceholder": "Entrez votre mot de passe",
       "discovering": "Découverte de l'organisation...",
       "findOrganizationHelp": "Entrez votre email professionnel pour trouver votre organisation",
       "organizationFound": "Organisation trouvée : {{organization}}",
@@ -29,6 +31,7 @@
       "forgotPassword": "Mot de passe oublié ?",
       "signIn": "Se Connecter",
       "signInWith": "Se connecter avec {{provider}}",
+      "orContinueWithPassword": "ou continuer avec un mot de passe",
       "mfaRequired": "L'authentification à deux facteurs est requise pour ce compte",
       "poweredBy": "Propulsé par",
       "helixBrand": "Nova Helix",
@@ -599,9 +602,12 @@
     "status": {
       "operational": "Opérationnel",
       "degraded": "Dégradé",
-      "partialOutage": "Panne Partielle",
-      "majorOutage": "Panne Majeure",
-      "underMaintenance": "En Maintenance"
+      "partial_outage": "Panne Partielle",
+      "major_outage": "Panne Majeure",
+      "under_maintenance": "En Maintenance",
+      "in_progress": "En Cours",
+      "completed": "Terminé",
+      "scheduled": "Planifié"
     },
     "severity": {
       "low": "Faible",


### PR DESCRIPTION
## Summary
- align service status translation keys with runtime values
- add missing maintenance status translations for all locales
- provide missing login password labels and "or continue with password" translations across locales

## Testing
- `pnpm --filter @nova/unified-ui test` *(fails: ReferenceError: TextEncoder is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68af0f209d18833385d12416a9e8030f